### PR TITLE
Add Internationalization Via Vue-i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,53 @@
 # The Carbon Challenge [![Netlify Status](https://api.netlify.com/api/v1/badges/59e1b698-b856-4584-af4d-171d326b44ea/deploy-status)](https://app.netlify.com/sites/carbon-challenge/deploys) ![GitHub Action status](https://github.com/vkoves/carbon-challenge/actions/workflows/tests.yml/badge.svg)
 
-
 The Carbon challenge interactive simulator/game. Powered by [Vue.js 3][vue].
 
-## Project setup
+## Language Support
+
+The Carbon Challenge supports multiple languages, which can easily be tweaked in
+the `constants.ts`. We welcome any help adding new languages or fixing
+translations!
+
+## Project Setup
+
+Just clone, and as long as you have [Yarn][yarn] you can just run:
+
 ```
 yarn install
 ```
 
 ### Compiles and hot-reloads for development
+
+After setup, run:
+
 ```
 yarn serve
 ```
 
 ### Compiles and minifies for production
+
+After setup, run:
+
 ```
 yarn build
 ```
 
-### Running Tests (Unit Only)
+### Running Tests
+
+We only have unit tests right now. To run them, after setup run:
 
 ```
 yarn test:unit
 ```
 
-### Lints and fixes files
+### Lints and Auto Fixes Files
+
+After setup, run:
+
 ```
 yarn lint
 ```
 
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
-
-
 <!-- Link declarations-->
-[vue]: https://v3.vuejs.org/
+[vue]: https://v3.vuejs.org
+[yarn]: https://yarnpkg.com

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "core-js": "^3.6.5",
     "vue": "^3.0.0",
     "vue-class-component": "^8.0.0-0",
+    "vue-i18n": "^9.0.0",
     "vue-router": "^4.0.0-0"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,32 @@
 <template>
+  <a href="#main-content" class="btn -small focus-elem skip-btn">
+    Skip to Main Content
+  </a>
   <header>
-    <router-link to="/" class="btn">Home</router-link>
-    <router-link to="/simulator" class="btn">Simulator</router-link>
+    <div>
+      <router-link to="/" class="btn">
+        {{ $t('header.home') }}
+      </router-link>
+      <router-link to="/simulator" class="btn">
+        {{ $t('header.simulator') }}
+      </router-link>
+    </div>
+
+    <div class="lang-selector">
+      <label for="lang-select">
+        {{ $t('header.language') }}
+        <img src="@/assets/earth.svg" alt="">
+      </label>
+      <select v-model="$i18n.locale">
+        <option v-for="langObj in AvailableLanguages"
+          :key="`${langObj.locale}`"
+          :value="langObj.locale">
+          {{ langObj.name }}
+        </option>
+      </select>
+    </div>
   </header>
-  <main>
+  <main id="main-content">
     <router-view v-slot="{ Component }">
       <transition name="fade" mode="out-in">
         <component :is="Component" />
@@ -15,8 +38,13 @@
 <script lang="ts">
 import { Options, Vue } from 'vue-class-component';
 
+import { AvailableLanguages } from './constants';
+
 @Options({
   name: 'App',
+  data: () => ({
+    AvailableLanguages: AvailableLanguages,
+  })
 })
 
 export default class App extends Vue { }
@@ -25,7 +53,22 @@ export default class App extends Vue { }
 <style lang="scss">
 @import './styles/main';
 
+.skip-btn {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0;
+  background: $dark-blue;
+  z-index: 10;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
 header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   background-color: transparent;
   padding: 1rem 2rem;
   position: absolute;
@@ -41,6 +84,27 @@ header {
     color: $dark-blue;
 
     + a { margin-left: 1rem; }
+  }
+
+  .lang-selector {
+    label {
+      display: inline-flex;
+      align-items: center;
+      color: $white;
+      font-weight: bold;
+
+      img {
+        height: 1.25rem;
+        margin-left: 0.5rem;
+      }
+    }
+
+    select {
+      margin-left: 1rem;
+      font-weight: bold;
+      font-size: 1rem;
+      padding: 0.25rem;
+    }
   }
 }
 </style>

--- a/src/assets/earth.svg
+++ b/src/assets/earth.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="512"
+   height="512"
+   viewBox="0 0 512 512"
+   id="svg7"
+   sodipodi:docname="earth.svg"
+   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)">
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="732"
+     inkscape:window-height="480"
+     id="namedview9"
+     showgrid="false"
+     inkscape:zoom="1.8203125"
+     inkscape:cx="256"
+     inkscape:cy="256"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7" />
+  <title
+     id="title2" />
+  <g
+     id="icomoon-ignore" />
+  <path
+     d="M256 0c-141.385 0-256 114.615-256 256s114.615 256 256 256 256-114.615 256-256-114.615-256-256-256zM256 480.001c-31.479 0-61.436-6.506-88.615-18.226l116.574-131.145c2.603-2.929 4.041-6.711 4.041-10.63v-48c0-8.837-7.163-16-16-16-56.495 0-116.102-58.731-116.687-59.313-3-3.001-7.070-4.687-11.313-4.687h-64c-8.836 0-16 7.164-16 16v96c0 6.061 3.424 11.601 8.845 14.311l55.155 27.578v93.943c-58.026-40.478-96-107.716-96-183.832 0-34.357 7.745-66.903 21.569-96h58.431c4.244 0 8.313-1.686 11.314-4.686l64-64c3-3.001 4.686-7.070 4.686-11.314v-38.706c20.281-6.037 41.759-9.294 64-9.294 35.203 0 68.502 8.13 98.141 22.6-2.072 1.751-4.088 3.582-6.023 5.518-18.133 18.132-28.118 42.239-28.118 67.882s9.985 49.75 28.118 67.882c18.217 18.216 42.609 28.132 67.817 28.13 1.583 0 3.171-0.040 4.759-0.118 6.907 25.901 19.376 93.328-4.202 186.167-0.222 0.872-0.348 1.744-0.421 2.612-40.662 41.54-97.35 67.328-160.071 67.328z"
+     id="path5"
+     style="fill:#ffffff" />
+</svg>

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="inner">
-    <h1>Carbon Challenge</h1>
+    <h1>{{ $t('title') }}</h1>
 
     <div class="main-cont">
       <div class="thermometer">
@@ -12,7 +12,7 @@
 
         <div class="text">
           <p class="temp">{{ avgTempRise.toFixed(2) }} °C</p>
-          <p class="label">Avg. Global Temperature Increase</p>
+          <p class="label">{{ $t('simulator.avgTempLabel') }}</p>
         </div>
       </div>
 

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -3,20 +3,23 @@
     <div class="hero">
       <div class="hero-inner">
         <h1 class="huge-text">
-          The Carbon Challenge
+          {{ $t('title') }}
         </h1>
 
         <p class="tagline big-text">
-          Climate change is big. <br>
-          So we have to go even bigger.
+          {{ $t('intro.slogan1') }} <br>
+          {{ $t('intro.slogan2') }}
         </p>
 
-        <router-link to="/simulator" class="btn">Enter</router-link>
+        <router-link to="/simulator" class="btn">
+          {{ $t('intro.startBtn') }}
+        </router-link>
       </div>
     </div>
 
     <div class="hero">
       <div class="hero-inner">
+        <!-- TODO: Move into i18n text -->
         <h2 class="larger-text">Try your hand at solving climate change</h2>
 
         <p>
@@ -58,5 +61,10 @@ export default class Intro extends Vue { }
     color: $white;
     text-align: center;
   }
+}
+
+.tagline {
+  margin-left: auto;
+  margin-right: auto;
 }
 </style>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,48 @@
 /** The width of our simulator grid */
 export const GridWidth = 4;
+
+export const AvailableLanguages = [{
+  locale: 'en',
+  name: 'English'
+}, {
+  locale: 'es',
+  name: 'Español'
+}];
+
+export const AllLanguageData = {
+  en: {
+    title: 'The Carbon Challenge',
+    header: {
+      home: 'Home',
+      simulator: 'Simulator',
+      language: 'Language',
+    },
+    intro: {
+      slogan1: 'Climate change is big.',
+      slogan2: 'So we have to go even bigger.',
+      startBtn: 'Let\'s Go'
+    },
+    simulator: {
+      avgTempLabel: 'Average Global Temperature Increase',
+    }
+  },
+  // NOTE: Spanish translations are work in progress, and mostly for testing
+  // internationalization
+  es: {
+    title: 'El Desafío Del Carbono',
+    header: {
+      home: 'Hogar',
+      simulator: 'Simulador',
+      language: 'Lingua',
+    },
+    intro: {
+      slogan1: 'El cambio climático es grande.',
+      slogan2: 'Así que tenemos que ir aún más grandes.',
+      startBtn: 'Vamos'
+    },
+    simulator: {
+      avgTempLabel: 'Aumento de la temperatura global promedio',
+    }
+  }
+};
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,16 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import { AllLanguageData } from './constants';
 
-createApp(App).use(router).mount('#app')
+import { createI18n } from 'vue-i18n'
+
+const i18n = createI18n({
+  locale: 'en',
+  messages: AllLanguageData,
+});
+
+createApp(App)
+  .use(router)
+  .use(i18n)
+  .mount('#app')

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -11,10 +11,13 @@
 @import 'variables/spacing';
 
 body {
+  background: linear-gradient($dark-blue, $blue);
+}
+
+body, select, button {
   font-family: 'Roboto', sans-serif;
   line-height: 1.25;
   color: $text-grey;
-  background: linear-gradient($dark-blue, $blue);
 }
 
 body, html, #app, main {
@@ -40,6 +43,15 @@ p {
 .larger-text { font-size: 2rem; }
 .big-text { font-size: 1.5rem; }
 
+/**
+ * A CSS class for buttons and links that only show on focus
+ */
+.focus-elem {
+  opacity: 0;
+
+  &:focus { opacity: 1; }
+}
+
 button, a.btn {
   display: inline-block;
   cursor: pointer;
@@ -51,11 +63,26 @@ button, a.btn {
   background: $dark-blue;
   padding: 0.5rem 1.5rem;
   margin-top: 1rem;
-  color: white;
+  color: $white;
   border-radius: 0.25rem;
   font-weight: bold;
   font-size: 1.5rem;
-  transition: box-shadow 0.3s;
+
+  &:hover, &:focus {
+    outline: none;
+    box-shadow: 0px 0px 2px 5px rgba(255, 255, 255);
+  }
+
+  &.-small { font-size: 1rem; }
+}
+
+select {
+  background-color: $white;
+  border-radius: 0.25rem;
+}
+
+select, .btn {
+  transition: box-shadow 0.3s, opacity 0.3s;
 
   &:hover, &:focus {
     outline: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,6 +804,39 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
+"@intlify/core-base@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.0.0.tgz#3de223b8532c535d022e5be58f7d56a26d2fb12f"
+  dependencies:
+    "@intlify/message-compiler" "9.0.0"
+    "@intlify/message-resolver" "9.0.0"
+    "@intlify/runtime" "9.0.0"
+    "@intlify/shared" "9.0.0"
+
+"@intlify/message-compiler@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.0.0.tgz#8a1079f8aebcde33057ce769817691ce27ad3e0d"
+  dependencies:
+    "@intlify/message-resolver" "9.0.0"
+    "@intlify/shared" "9.0.0"
+    source-map "0.6.1"
+
+"@intlify/message-resolver@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.0.0.tgz#0077ec24606b6486d238bdef9044e27729f4782c"
+
+"@intlify/runtime@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@intlify/runtime/-/runtime-9.0.0.tgz#bf9415ff90c746a9be38a5c32f71cbbe9848eee8"
+  dependencies:
+    "@intlify/message-compiler" "9.0.0"
+    "@intlify/message-resolver" "9.0.0"
+    "@intlify/shared" "9.0.0"
+
+"@intlify/shared@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.0.0.tgz#d85b3b5f9033f377c5cf2202cf2459aa49948f36"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -1365,6 +1398,10 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
+
+"@vue/devtools-api@^6.0.0-beta.5":
+  version "6.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.7.tgz#1d306613c93b9a837a3776b1b9255502662f850f"
 
 "@vue/eslint-config-typescript@^5.0.2":
   version "5.1.0"
@@ -7155,13 +7192,13 @@ source-map-url@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
 
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 source-map@^0.7.3:
   version "0.7.3"
@@ -7965,6 +8002,14 @@ vue-eslint-parser@^7.0.0, vue-eslint-parser@^7.6.0:
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
+
+vue-i18n@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-9.0.0.tgz#a04c41d5ed3d5a068e923517bfaa0abcbc84e174"
+  dependencies:
+    "@intlify/core-base" "9.0.0"
+    "@intlify/shared" "9.0.0"
+    "@vue/devtools-api" "^6.0.0-beta.5"
 
 "vue-loader-v16@npm:vue-loader@^16.1.0":
   version "16.1.2"


### PR DESCRIPTION
Adds the [Vue i18n plugin](https://vue-i18n.intlify.dev/) to allow for switching languages. All rendered text except the hero text is also now in the internationalization constants, with a starter Spanish translation from Google Translate. Here's a demo showing this in action:

![Peek 2021-03-09 20-39](https://user-images.githubusercontent.com/3187531/110567737-993bdc00-8117-11eb-9afc-f5b0821666d5.gif)
