### PR TITLE
Start Tile Options and Basic Overlay

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -20,16 +20,31 @@
         <div class="game-board -main">
           <Tile v-for="tile in tiles" v-bind:key="tile.id"
             :tile="tile"
-            @data-updated="recalculateTemps()" />
+            @data-updated="selectTile(tile)" />
         </div>
       </div>
+    </div>
+
+    <div @click="clearSelectedTile()"
+      class="overlay" :class="{ '-open': showingTileMenu }">
+      <transition name="slide-fade" v-show="selectedTile">
+        <div class="sidebar" v-show="showingTileMenu">
+          <button @click="clearSelectedTile()" class="btn">
+            {{ $t('simulator.close') }}
+          </button>
+          <div v-if="selectedTile">
+            <h2>{{ $t(`simulator.tileTypes.${selectedTile.type}`) }}</h2>
+          </div>
+        </div>
+      </transition>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { Options, Vue } from 'vue-class-component';
-import { Simulator } from '../simulator';
+// eslint-disable-next-line no-unused-vars
+import { Simulator, ITile } from '../simulator';
 import Tile from './Tile.vue';
 
 @Options({
@@ -39,6 +54,8 @@ import Tile from './Tile.vue';
   },
   data: () => ({
     tiles: Simulator.generateTiles(),
+    selectedTile: null,
+    showingTileMenu: false,
     avgTempRise: 0,
     avgTempAdjusted: 0,
     MaxTempRise: 3,
@@ -49,6 +66,17 @@ import Tile from './Tile.vue';
 
       // Convert decimal temperature rise to a %
       this.avgTempAdjusted = (this.avgTempRise / this.MaxTempRise) * 100;
+    },
+
+    selectTile(tile: ITile) {
+      this.selectedTile = tile;
+      this.showingTileMenu = true;
+
+      this.recalculateTemps();
+    },
+
+    clearSelectedTile() {
+      this.showingTileMenu = false;
     }
   }
 })
@@ -151,5 +179,46 @@ export default class Game extends Vue { }
   width: $boardSize;
   height: $boardSize;
   margin: auto;
+}
+
+.overlay {
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  transition: background-color 0.3s;
+  background-color: rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+
+  &:not(.-open) {
+    background-color: transparent;
+    pointer-events: none;
+  }
+
+  &.-open .sidebar {
+    // right: 0;
+  }
+
+  &:not(.-open) .sidebar {
+    // right: -40%;
+  }
+
+  .sidebar {
+    // position: absolute;
+    // transition: right 0.5s;
+    padding: 50px;
+    height: 100%;
+    width: 40%;
+    box-sizing: border-box;
+    backdrop-filter: brightness(0.5) blur(10px);
+
+    h2 {
+      margin-top: 1rem;
+    }
+  }
 }
 </style>

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -27,14 +27,19 @@
 
     <div @click="clearSelectedTile()"
       class="overlay" :class="{ '-open': showingTileMenu }">
-      <transition name="slide-fade" v-show="selectedTile">
-        <div class="sidebar" v-show="showingTileMenu">
+      <transition name="slide-fade">
+        <div class="sidebar" v-if="showingTileMenu">
           <button @click="clearSelectedTile()" class="btn">
             {{ $t('simulator.close') }}
           </button>
-          <div v-if="selectedTile">
-            <h2>{{ $t(`simulator.tileTypes.${selectedTile.type}`) }}</h2>
-          </div>
+          <h2>{{ $t(`simulator.tileTypes.${selectedTile.type}`) }}</h2>
+
+          <ul v-for="(option, key) in selectedTile.options" :key="key">
+            <li>
+              {{ key }}
+              {{ option }}
+            </li>
+          </ul>
         </div>
       </transition>
     </div>
@@ -44,7 +49,7 @@
 <script lang="ts">
 import { Options, Vue } from 'vue-class-component';
 // eslint-disable-next-line no-unused-vars
-import { Simulator, ITile } from '../simulator';
+import { Simulator, TileObj } from '../simulator';
 import Tile from './Tile.vue';
 
 @Options({
@@ -68,7 +73,7 @@ import Tile from './Tile.vue';
       this.avgTempAdjusted = (this.avgTempRise / this.MaxTempRise) * 100;
     },
 
-    selectTile(tile: ITile) {
+    selectTile(tile: TileObj) {
       this.selectedTile = tile;
       this.showingTileMenu = true;
 

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -13,19 +13,19 @@
 import { Options, Vue } from 'vue-class-component';
 
 // eslint-disable-next-line
-import { ITile, TileType } from '../simulator';
+import { TileObj, TileType } from '../simulator';
 
 @Options({
   name: 'Game',
   props: {
-    tile: {} as ITile,
+    tile: {} as TileObj,
   },
   data: () => ({
     // Expose TileType enum to template
     TileType: TileType,
   }),
   emits: {
-    dataUpdated(newTile: ITile): ITile { return newTile; },
+    dataUpdated(newTile: TileObj): TileObj { return newTile; },
   },
   methods: {
     emitTile(): void {

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -1,9 +1,9 @@
 <template>
-  <button class="tile" @click="emitTile()">
-    <div class="ground"></div>
+  <button class="tile" :disabled="tile.type === TileType.Empty"
+    @click="emitTile()">
     <div class="above-ground">
       <span v-if="tile.type !== TileType.Empty">
-        {{ tile.type }}
+        {{ $t(`simulator.tileTypes.${tile.type}`) }}
       </span>
     </div>
   </button>
@@ -51,27 +51,19 @@ export default class Game extends Vue { }
   align-items: center;
   justify-content: center;
   transition: transform 0.3s, box-shadow 0.3s, border 0.3s;
+  background: $ground-green;
   border: solid 5px lighten($ground-green, 5%);
   margin: 1px;
 
   // Fix weird flicker in Chrome
   -webkit-transform: translate3d(0, 0, 0);
 
-  &:hover, &:focus {
+  // Show a prominent effect on non-empty tiles being hovered or focused
+  &:not(:disabled):hover, &:focus {
     outline: none;
-    transform: translate(-10px, -10px);
+    transform: translate(-0.6rem, -0.6rem);
     box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);
-    border: solid 5px $white;
-  }
-
-  .ground {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    box-sizing: border-box;
-    background: $ground-green;
+    border-color: $white;
   }
 
   // Reverse the game board rotation and skew to straighten above ground

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,16 @@ export const AllLanguageData = {
     },
     simulator: {
       avgTempLabel: 'Average Global Temperature Increase',
+      close: 'Close',
+      // Should include all value from the TileType enum
+      tileTypes: {
+        power: 'Power',
+        farm: 'Farm',
+        house: 'House',
+        office: 'Office',
+        factory: 'Factory',
+        empty: 'Empty',
+      }
     }
   },
   // NOTE: Spanish translations are work in progress, and mostly for testing
@@ -42,6 +52,16 @@ export const AllLanguageData = {
     },
     simulator: {
       avgTempLabel: 'Aumento de la temperatura global promedio',
+      close: 'Cerrar',
+      // Should include all value from the TileType enum
+      tileTypes: {
+        power: 'Power',
+        farm: 'Farm',
+        house: 'House',
+        office: 'Office',
+        factory: 'Factory',
+        empty: 'Empty',
+      }
     }
   }
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export const AllLanguageData = {
       close: 'Close',
       // Should include all value from the TileType enum
       tileTypes: {
-        power: 'Power',
+        power: 'Power Plant',
         farm: 'Farm',
         house: 'House',
         office: 'Office',
@@ -55,12 +55,12 @@ export const AllLanguageData = {
       close: 'Cerrar',
       // Should include all value from the TileType enum
       tileTypes: {
-        power: 'Power',
-        farm: 'Farm',
-        house: 'House',
-        office: 'Office',
-        factory: 'Factory',
-        empty: 'Empty',
+        power: 'Planta de energía',
+        farm: 'Granja',
+        house: 'Casa',
+        office: 'Oficina',
+        factory: 'Fábrica',
+        empty: 'Vacío',
       }
     }
   }

--- a/styles/animations.scss
+++ b/styles/animations.scss
@@ -17,3 +17,14 @@
 .fade-leave-to {
   opacity: 0;
 }
+
+/**
+ * Slide fade
+ */
+.slide-fade-enter-active, .slide-fade-leave-active {
+  transition: all 0.5s ease;
+}
+.slide-fade-enter-from, .slide-fade-leave-to {
+  transform: translateX(10rem);
+  opacity: 0;
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -54,9 +54,10 @@ p {
 
 button, a.btn {
   display: inline-block;
-  cursor: pointer;
   border: none;
   text-decoration: none;
+
+  &:not(:disabled) { cursor: pointer; }
 }
 
 .btn {

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -49,6 +49,8 @@ p {
 .focus-elem {
   opacity: 0;
 
+  &:not(:focus) { pointer-events: none; }
+
   &:focus { opacity: 1; }
 }
 


### PR DESCRIPTION
Moves from a Tile interface (`ITile`) to a Tile class (`TileObj`) and starts the logic for instantiating the default options. Also adds the UI to view a tile's options with a basic overlay. Here's a demo:

![Peek 2021-03-09 22-08](https://user-images.githubusercontent.com/3187531/110575159-0eada980-8124-11eb-8e4b-21beda98017c.gif)

You'll also notice internationalization has been added for the tile types, both on the board (even though those are temporary) and in the overlay.
