### PR TITLE
Implement Proper Tile Options UI & Homepage Placeholders

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
         {{ $t('header.language') }}
         <img src="@/assets/earth.svg" alt="">
       </label>
-      <select v-model="$i18n.locale">
+      <select v-model="$i18n.locale" id="lang-select">
         <option v-for="langObj in AvailableLanguages"
           :key="`${langObj.locale}`"
           :value="langObj.locale">
@@ -69,8 +69,8 @@ header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: transparent;
-  padding: 1rem 2rem;
+  background-color: $dark-blue;
+  padding: 0.75rem 2rem;
   position: absolute;
   width: 100%;
   z-index: 1;

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,7 +80,7 @@ header {
     margin: 0;
     font-size: 1rem;
     background-color: $white;
-    border: solid 2px $dark-blue;
+    border: solid 0.125rem $dark-blue;
     color: $dark-blue;
 
     + a { margin-left: 1rem; }

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -18,45 +18,18 @@
 
       <div class="boards-cont">
         <div class="game-board -main">
-          <Tile v-for="tile in tiles" v-bind:key="tile.id"
+          <Tile v-for="tile in tiles"
+            v-bind:key="tile.id"
             :tile="tile"
+            :class="{ '-active': tile.id === selectedTile?.id }"
             @data-updated="selectTile(tile)" />
         </div>
       </div>
     </div>
 
-    <div @click="clearSelectedTile()"
-      class="overlay" :class="{ '-open': showingTileMenu }">
-      <transition name="slide-fade">
-        <section class="sidebar" v-if="showingTileMenu"
-          @click="handleSidebarClick">
-          <button @click="clearSelectedTile()" class="btn" ref="closeBtn">
-            {{ $t('simulator.close') }}
-          </button>
-
-          <h2>{{ $t(`simulator.tileTypes.${selectedTile.type}`) }}</h2>
-
-          <div v-for="(option, key) in selectedTile.options" :key="key">
-              <h3>{{ $t(`simulator.tileOptions.${key}`) }}</h3>
-
-              <ul>
-                <li>
-                  {{ $t('simulator.tileOverlay.current') }}:
-                  {{ option.current * 100 + '%' }}
-                </li>
-                <li>
-                  {{ $t('simulator.tileOverlay.target') }}:
-                  {{ option.target * 100 + '%' }}
-                </li>
-                <li>
-                  {{ $t('simulator.tileOverlay.targetYear') }}:
-                  {{ option.targetYear }}
-                </li>
-              </ul>
-          </div>
-        </section>
-      </transition>
-    </div>
+    <TileOverlay
+      :tile="selectedTile"
+      @closed="tileOverlayClosed()"></TileOverlay>
   </div>
 </template>
 
@@ -65,11 +38,13 @@ import { Options, Vue } from 'vue-class-component';
 // eslint-disable-next-line no-unused-vars
 import { Simulator, TileObj } from '../simulator';
 import Tile from './Tile.vue';
+import TileOverlay from './TileOverlay.vue';
 
 @Options({
   name: 'Game',
   components: {
     Tile,
+    TileOverlay,
   },
   data: () => ({
     tiles: Simulator.generateTiles(),
@@ -89,32 +64,12 @@ import Tile from './Tile.vue';
 
     selectTile(tile: TileObj) {
       this.selectedTile = tile;
-      this.showingTileMenu = true;
 
       this.recalculateTemps();
-
-      // Focus the first focusable element in the overlay - the close button
-      // TODO: Make the overlay trap focus
-      setTimeout(() => {
-        this.lastFocusedElem = document.activeElement;
-
-        this.$refs.closeBtn.focus();
-      });
     },
 
-    handleSidebarClick(clickEvent: MouseEvent) {
-      clickEvent.stopPropagation();
-    },
-
-    clearSelectedTile() {
-      this.showingTileMenu = false;
-
-      // On close of the overlay, refocus the last element
-      setTimeout(() => {
-        if (this.lastFocusedElem) {
-          this.lastFocusedElem.focus();
-        }
-      });
+    tileOverlayClosed() {
+      this.selectedTile = null;
     }
   }
 })
@@ -217,44 +172,5 @@ export default class Game extends Vue { }
   width: $boardSize;
   height: $boardSize;
   margin: auto;
-}
-
-.overlay {
-  display: flex;
-  justify-content: flex-end;
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  right: 0;
-  z-index: 2;
-  transition: background-color 0.3s;
-  background-color: rgba(0, 0, 0, 0.25);
-  overflow: hidden;
-
-  &:not(.-open) {
-    background-color: transparent;
-    pointer-events: none;
-  }
-
-  &.-open .sidebar {
-    // right: 0;
-  }
-
-  &:not(.-open) .sidebar {
-    // right: -40%;
-  }
-
-  .sidebar {
-    // position: absolute;
-    // transition: right 0.5s;
-    padding: 50px;
-    height: 100%;
-    width: 40%;
-    box-sizing: border-box;
-    backdrop-filter: brightness(0.5) blur(10px);
-
-    h2, h3 { margin-top: 1rem; }
-  }
 }
 </style>

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -28,7 +28,8 @@
     <div @click="clearSelectedTile()"
       class="overlay" :class="{ '-open': showingTileMenu }">
       <transition name="slide-fade">
-        <div class="sidebar" v-if="showingTileMenu">
+        <section class="sidebar" v-if="showingTileMenu"
+          @click="handleSidebarClick">
           <button @click="clearSelectedTile()" class="btn" ref="closeBtn">
             {{ $t('simulator.close') }}
           </button>
@@ -53,7 +54,7 @@
                 </li>
               </ul>
           </div>
-        </div>
+        </section>
       </transition>
     </div>
   </div>
@@ -99,6 +100,10 @@ import Tile from './Tile.vue';
 
         this.$refs.closeBtn.focus();
       });
+    },
+
+    handleSidebarClick(clickEvent: MouseEvent) {
+      clickEvent.stopPropagation();
     },
 
     clearSelectedTile() {

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -29,9 +29,10 @@
       class="overlay" :class="{ '-open': showingTileMenu }">
       <transition name="slide-fade">
         <div class="sidebar" v-if="showingTileMenu">
-          <button @click="clearSelectedTile()" class="btn">
+          <button @click="clearSelectedTile()" class="btn" ref="closeBtn">
             {{ $t('simulator.close') }}
           </button>
+
           <h2>{{ $t(`simulator.tileTypes.${selectedTile.type}`) }}</h2>
 
           <div v-for="(option, key) in selectedTile.options" :key="key">
@@ -90,10 +91,25 @@ import Tile from './Tile.vue';
       this.showingTileMenu = true;
 
       this.recalculateTemps();
+
+      // Focus the first focusable element in the overlay - the close button
+      // TODO: Make the overlay trap focus
+      setTimeout(() => {
+        this.lastFocusedElem = document.activeElement;
+
+        this.$refs.closeBtn.focus();
+      });
     },
 
     clearSelectedTile() {
       this.showingTileMenu = false;
+
+      // On close of the overlay, refocus the last element
+      setTimeout(() => {
+        if (this.lastFocusedElem) {
+          this.lastFocusedElem.focus();
+        }
+      });
     }
   }
 })

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -84,7 +84,7 @@ export default class Game extends Vue { }
 @import './styles/variables/spacing';
 
 .inner {
-  padding: 100px;
+  padding: 6rem;
   color: $white;
 }
 
@@ -94,9 +94,9 @@ export default class Game extends Vue { }
 }
 
 .thermometer {
-  $thermometer-width: 80px;
-  $inner-width: 30px;
-  $border-width: 6px;
+  $thermometer-width: 5rem;
+  $inner-width: 1.875rem;
+  $border-width: 0.375rem;
 
   position: relative;
   width: $thermometer-width;
@@ -124,15 +124,15 @@ export default class Game extends Vue { }
     background-color: $red;
     width: $inner-width;
     position: absolute;
-    height: 40px;
+    height: 2.5rem;
     z-index: 2;
     margin: auto;
     left: 0;
     right: 0;
-    bottom: 0px;
+    bottom: 0;
     height: 0;
     transition: height 1s;
-    border-bottom: solid 35px $red;
+    border-bottom: solid 2.1875rem $red;
   }
 
   .bulb {

--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -22,14 +22,15 @@
             v-bind:key="tile.id"
             :tile="tile"
             :class="{ '-active': tile.id === selectedTile?.id }"
-            @data-updated="selectTile(tile)" />
+            @selected="selectTile(tile)" />
         </div>
       </div>
     </div>
 
     <TileOverlay
       :tile="selectedTile"
-      @closed="tileOverlayClosed()"></TileOverlay>
+      @closed="tileOverlayClosed()"
+      @tile-updated="tileUpdated(tile)"></TileOverlay>
   </div>
 </template>
 
@@ -64,7 +65,10 @@ import TileOverlay from './TileOverlay.vue';
 
     selectTile(tile: TileObj) {
       this.selectedTile = tile;
+    },
 
+    // Takes in a TileObj, but we don't use that at the moment
+    tileUpdated() {
       this.recalculateTemps();
     },
 

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -94,7 +94,7 @@ export default class Intro extends Vue { }
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    max-width: 1200px;
+    max-width: 75rem;
     margin: auto;
   }
 

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="hero">
+    <div class="hero -primary">
       <div class="hero-inner">
         <h1 class="huge-text">
           {{ $t('title') }}
@@ -17,16 +17,43 @@
       </div>
     </div>
 
+    <!-- TODO: Move all hero copy into i18n text -->
     <div class="hero">
       <div class="hero-inner">
-        <!-- TODO: Move into i18n text -->
-        <h2 class="larger-text">Try your hand at solving climate change</h2>
+        <div class="text-cont">
+          <h2 class="larger-text">
+            Try Out Policies to <br>
+            Combat Climate Change
+          </h2>
 
-        <p>
-          Climate change isn't going to be solved over night, and we also know there's
-          a limit to individual responsibility. But to advocate for policies, you need
-          to know the impact. Try out policies in the Carbon Challenge simulation.
-        </p>
+          <p>
+            Test out policies from moving to renewable energy, transitioning to
+            electric cars, and even geo-engineering, and see how they impact our
+            climate.
+          </p>
+        </div>
+
+        <div class="img-cont">
+        </div>
+      </div>
+    </div>
+
+    <div class="hero -blue">
+      <div class="hero-inner">
+        <div class="img-cont">
+        </div>
+
+        <div class="text-cont">
+          <h2 class="larger-text">
+            Learn How You Can <br>
+            Reduce Your Impact
+          </h2>
+
+          <p>
+            Look at the impact of changes you can make in your home, like
+            composting, installing solar panels, or driving less.
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -52,14 +79,41 @@ export default class Intro extends Vue { }
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: $x-large $large;
-  min-height: 40vh;
+  padding: 10rem $large;
   background-color: $white;
 
-  &:first-of-type {
+  &.-primary {
     background: linear-gradient($dark-blue, $blue);
     color: $white;
     text-align: center;
+    padding: 15rem $large;
+  }
+
+  &:not(.-primary) .hero-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    max-width: 1200px;
+    margin: auto;
+  }
+
+  &.-blue {
+    background-color: $dark-blue;
+    color: $white;
+
+    .img-cont { background-color: $white; }
+  }
+
+  .img-cont {
+    background-color: $blue;
+    width: 25%;
+    border-radius: 10rem;
+    padding: 9rem 0;
+  }
+
+  .text-cont {
+    max-width: 31.25rem;
   }
 }
 

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -52,7 +52,7 @@ export default class Intro extends Vue { }
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: $large;
+  padding: $x-large $large;
   min-height: 40vh;
   background-color: $white;
 

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -20,6 +20,9 @@
     <!-- TODO: Move all hero copy into i18n text -->
     <div class="hero">
       <div class="hero-inner">
+        <div class="img-cont">
+        </div>
+
         <div class="text-cont">
           <h2 class="larger-text">
             Try Out Policies to <br>
@@ -32,17 +35,11 @@
             climate.
           </p>
         </div>
-
-        <div class="img-cont">
-        </div>
       </div>
     </div>
 
     <div class="hero -blue">
       <div class="hero-inner">
-        <div class="img-cont">
-        </div>
-
         <div class="text-cont">
           <h2 class="larger-text">
             Learn How You Can <br>
@@ -53,6 +50,9 @@
             Look at the impact of changes you can make in your home, like
             composting, installing solar panels, or driving less.
           </p>
+        </div>
+
+        <div class="img-cont">
         </div>
       </div>
     </div>
@@ -120,5 +120,15 @@ export default class Intro extends Vue { }
 .tagline {
   margin-left: auto;
   margin-right: auto;
+}
+
+@media (max-width: $mobile-max-width) {
+  .hero:not(.primary) .hero-inner {
+    flex-direction: column;
+
+    > div:last-of-type {
+      margin-top: $x-large;
+    }
+  }
 }
 </style>

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -61,7 +61,7 @@ export default class Game extends Vue { }
   -webkit-transform: translate3d(0, 0, 0);
 
   // Show a prominent effect on non-empty tiles being hovered or focused
-  &:not(:disabled):hover, &:focus {
+  &:not(:disabled):hover, &:focus, &.-active {
     outline: none;
     transform: translate(-0.6rem, -0.6rem);
     box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -58,8 +58,8 @@ export default class Game extends Vue { }
   justify-content: center;
   transition: transform 0.3s, box-shadow 0.3s, border 0.3s;
   background: $ground-green;
-  border: solid 5px lighten($ground-green, 5%);
-  margin: 1px;
+  border: solid 0.25rem lighten($ground-green, 5%);
+  margin: 0rem;
 
   // Fix weird flicker in Chrome
   -webkit-transform: translate3d(0, 0, 0);
@@ -68,7 +68,7 @@ export default class Game extends Vue { }
   &:not(:disabled):hover, &:focus, &.-active {
     outline: none;
     transform: translate(-0.6rem, -0.6rem);
-    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.5);
+    box-shadow: 0.25rem 0.25rem 0.25rem rgba(0, 0, 0, 0.5);
     border-color: $white;
   }
 

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Show tile as a <div> if it's empty, <button> if not -->
-  <button v-if="tile.type !== TileType.Empty" class="tile" @click="emitTile()">
+  <button v-if="tile.type !== TileType.Empty" class="tile" @click="tileSelected()">
     <div class="above-ground">
       <img v-if="tile.type === TileType.House"
         src="@/assets/House.svg"
@@ -12,7 +12,7 @@
     </div>
   </button>
 
-  <div class="tile" v-else></div>
+  <div class="tile -empty" v-else></div>
 </template>
 
 <script lang="ts">
@@ -31,11 +31,11 @@ import { TileObj, TileType } from '../simulator';
     TileType: TileType,
   }),
   emits: {
-    dataUpdated(newTile: TileObj): TileObj { return newTile; },
+    selected(newTile: TileObj): TileObj { return newTile; },
   },
   methods: {
-    emitTile(): void {
-      this.$emit('dataUpdated', this.tile);
+    tileSelected(): void {
+      this.$emit('selected', this.tile);
     }
   }
 })
@@ -65,7 +65,7 @@ export default class Game extends Vue { }
   -webkit-transform: translate3d(0, 0, 0);
 
   // Show a prominent effect on non-empty tiles being hovered or focused
-  &:not(:disabled):hover, &:focus, &.-active {
+  &:not(.-empty):hover, &:focus, &.-active {
     outline: none;
     transform: translate(-0.6rem, -0.6rem);
     box-shadow: 0.25rem 0.25rem 0.25rem rgba(0, 0, 0, 0.5);

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -1,14 +1,18 @@
 <template>
-  <button class="tile" :disabled="tile.type === TileType.Empty"
-    @click="emitTile()">
+  <!-- Show tile as a <div> if it's empty, <button> if not -->
+  <button v-if="tile.type !== TileType.Empty" class="tile" @click="emitTile()">
     <div class="above-ground">
-      <img v-if="tile.type === TileType.House" src="@/assets/House.svg"
+      <img v-if="tile.type === TileType.House"
+        src="@/assets/House.svg"
         :alt="$t(`simulator.tileTypes.${tile.type}`)">
-      <span v-else-if="tile.type !== TileType.Empty">
+      <!-- TODO: Move all non empty tiles to images -->
+      <span v-else>
         {{ $t(`simulator.tileTypes.${tile.type}`) }}
       </span>
     </div>
   </button>
+
+  <div class="tile" v-else></div>
 </template>
 
 <script lang="ts">

--- a/src/components/TileOverlay.vue
+++ b/src/components/TileOverlay.vue
@@ -1,0 +1,144 @@
+<template>
+    <div @click="clearSelectedTile()"
+      class="overlay" :class="{ '-open': showingTileMenu }">
+      <transition name="slide-fade">
+        <section class="sidebar" v-show="showingTileMenu"
+          @click="handleSidebarClick">
+          <button @click="clearSelectedTile()" class="btn" ref="closeBtn">
+            {{ $t('simulator.close') }}
+          </button>
+
+          <div v-if="tile">
+              <h2>{{ $t(`simulator.tileTypes.${tile.type}`) }}</h2>
+
+              <div v-for="(option, key) in tile.options" :key="key">
+                  <h3>{{ $t(`simulator.tileOptions.${key}`) }}</h3>
+
+                  <ul>
+                    <li>
+                      {{ $t('simulator.tileOverlay.current') }}:
+                      {{ option.current * 100 + '%' }}
+                    </li>
+                    <li>
+                      {{ $t('simulator.tileOverlay.target') }}:
+                      {{ option.target * 100 + '%' }}
+                    </li>
+                    <li>
+                      {{ $t('simulator.tileOverlay.targetYear') }}:
+                      {{ option.targetYear }}
+                    </li>
+                  </ul>
+              </div>
+          </div>
+        </section>
+      </transition>
+    </div>
+</template>
+
+<script lang="ts">
+import { Options, Vue } from 'vue-class-component';
+// eslint-disable-next-line no-unused-vars
+import { TileObj } from '../simulator';
+
+const AnimDurationMs = 300;
+
+@Options({
+  props: {
+    // The tile whose options we're rendering
+    tile: {} as TileObj,
+  },
+  data: () => ({
+    showingTileMenu: false,
+    lastFocusedElem: null,
+  }),
+  emits: {
+    closed(): void { },
+  },
+  methods: {
+    clearSelectedTile() {
+      this.showingTileMenu = false;
+
+      // On close of the overlay, refocus the last element
+      if (this.lastFocusedElem) {
+        this.lastFocusedElem.focus();
+      }
+
+      // Emit closed event after fade animation is done
+      setTimeout(() => {
+        this.$emit('closed');
+      }, AnimDurationMs);
+    },
+
+    handleSidebarClick(clickEvent: MouseEvent) {
+      clickEvent.stopPropagation();
+    },
+  },
+  watch: {
+    // On tile changed
+    tile: function(newVal) {
+        if (!newVal) {
+            return;
+        }
+
+        this.showingTileMenu = true;
+
+        setTimeout(() => {
+            // Focus the first focusable element in the overlay - the close button
+            // TODO: Make the overlay trap focus
+            this.lastFocusedElem = document.activeElement;
+
+            this.$refs.closeBtn.focus();
+        });
+    }
+  }
+})
+
+export default class TileOverlay extends Vue { }
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped lang="scss">
+@import './styles/variables/board';
+@import './styles/variables/colors';
+@import './styles/variables/spacing';
+
+.overlay {
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  transition: background-color 0.3s;
+  background-color: rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+
+  &:not(.-open) {
+    background-color: transparent;
+    pointer-events: none;
+  }
+
+  &.-open .sidebar {
+    // right: 0;
+  }
+
+  &:not(.-open) .sidebar {
+    // right: -40%;
+  }
+
+  .sidebar {
+    // position: absolute;
+    // transition: right 0.5s;
+    padding: 50px;
+    height: 100%;
+    width: 40%;
+    box-sizing: border-box;
+    backdrop-filter: brightness(0.5) blur(10px);
+
+    h2, h3 { margin-top: 1rem; }
+  }
+}
+</style>
+

--- a/src/components/TileOverlay.vue
+++ b/src/components/TileOverlay.vue
@@ -120,22 +120,14 @@ export default class TileOverlay extends Vue { }
     pointer-events: none;
   }
 
-  &.-open .sidebar {
-    // right: 0;
-  }
-
-  &:not(.-open) .sidebar {
-    // right: -40%;
-  }
 
   .sidebar {
-    // position: absolute;
-    // transition: right 0.5s;
-    padding: 50px;
+    padding: 3rem 5rem;
     height: 100%;
     width: 40%;
     box-sizing: border-box;
-    backdrop-filter: brightness(0.5) blur(10px);
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(0.2rem);
 
     h2, h3 { margin-top: 1rem; }
   }

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -40,11 +40,23 @@ export enum TileOption {
  * A single tile option configuration, usually wrapped in IOptions.
  */
 export interface IOption {
-  /** A percentage expressed as a decimal */
+  /*
+    A percentage (0 - 100) representing the current value of this option.
+    This should come from real data and is only editable in magic mode (since
+    no policy instantly has an impact).
+   */
   current: number;
-  /** A percentage expressed as a decimal */
+
+  /**
+   * A percentage (0 - 100) representing the value this option will reach at the
+   * target year.
+   */
   target: number;
-  /** A full year (e.g. 2020) */
+
+  /**
+   * The year we reach our target policy goal, after which this value is
+   * maintained. Expressed as a full number (e.g. `2021`)
+   */
   targetYear: number;
 }
 
@@ -58,8 +70,8 @@ export interface IOption {
  * For example, the power tile may have renewable options like so:
  *
  * renewable: {
- *   current: 0,
- *   target: 1, // 100% as a decimal
+ *   current: 5,
+ *   target: 100,
  *   targetYear: 2050,
  * }
  *
@@ -77,30 +89,30 @@ export interface IOptions {
 
 const EmptyOption: IOption = {
   current: 0,
-  target: 1,
+  target: 100,
   targetYear: 2050,
 };
 
 export const DefaultTileOptions: { [ type: string ]: IOptions } = {
   [TileType.Factory]: {
-    [TileOption.RenewableShare]: EmptyOption,
+    [TileOption.RenewableShare]: Object.assign({}, EmptyOption),
   },
 
   [TileType.Farm]: {
-    [TileOption.Deforestation]: EmptyOption,
+    [TileOption.Deforestation]: Object.assign({}, EmptyOption),
   },
 
   [TileType.House]: {
-    [TileOption.ElectricCarShare]: EmptyOption,
-    [TileOption.ElectricHeating]: EmptyOption,
+    [TileOption.ElectricCarShare]: Object.assign({}, EmptyOption),
+    [TileOption.ElectricHeating]: Object.assign({}, EmptyOption),
   },
 
   [TileType.Office]: {
-    [TileOption.ElectricHeating]: EmptyOption,
+    [TileOption.ElectricHeating]: Object.assign({}, EmptyOption),
   },
 
   [TileType.Power]: {
-    [TileOption.RenewableShare]: EmptyOption,
+    [TileOption.RenewableShare]: Object.assign({}, EmptyOption),
   },
 };
 

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -73,7 +73,7 @@ button, a.btn {
 
   &:hover, &:focus {
     outline: none;
-    box-shadow: 0px 0px 2px 5px rgba(255, 255, 255);
+    box-shadow: 0 0 0.125rem 0.3rem $white;
   }
 
   &.-small { font-size: 1rem; }
@@ -89,6 +89,6 @@ select, .btn {
 
   &:hover, &:focus {
     outline: none;
-    box-shadow: 0px 0px 2px 5px rgba(255, 255, 255);
+    box-shadow: 0 0 0.125rem 0.3rem $white;
   }
 }

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -77,6 +77,11 @@ button, a.btn {
   }
 
   &.-small { font-size: 1rem; }
+
+  &.-grey {
+    background-color: $light-grey;
+    color: $text-grey;
+  }
 }
 
 select {

--- a/styles/variables/colors.scss
+++ b/styles/variables/colors.scss
@@ -5,6 +5,7 @@
 $blue: #5C76FF;
 $dark-blue: #2B00A7;
 $white: #FFFFFF;
+$light-grey: #DDDDDD;
 
 // Text colors
 $text-grey: #323232;

--- a/styles/variables/colors.scss
+++ b/styles/variables/colors.scss
@@ -7,4 +7,4 @@ $dark-blue: #2B00A7;
 $white: #FFFFFF;
 
 // Text colors
-$text-grey: #222222;
+$text-grey: #323232;

--- a/styles/variables/spacing.scss
+++ b/styles/variables/spacing.scss
@@ -4,3 +4,4 @@
 
 $standard: 1rem;
 $large: 2rem;
+$x-large: 6rem;

--- a/styles/variables/spacing.scss
+++ b/styles/variables/spacing.scss
@@ -2,6 +2,15 @@
  * Spacing Variables
  */
 
+/**
+ * Padding/margin sizes
+ */
 $standard: 1rem;
 $large: 2rem;
 $x-large: 6rem;
+
+
+/**
+ * Screen sizes
+ */
+$mobile-max-width: 801px;


### PR DESCRIPTION
Added proper UI for tile options, letting users actually drag the target value and year up and down and propagate changes. Also updated the homepage with new copy and placeholder spots for images. Here's two screenshots:

| Homepage | Simulator |
| --- | --- |
| ![localhost_8080_](https://user-images.githubusercontent.com/3187531/110735075-aa0b5100-81ee-11eb-9b94-1b4ffb5d3c3e.png) | ![Screenshot from 2021-03-10 22-17-21](https://user-images.githubusercontent.com/3187531/110735037-9d86f880-81ee-11eb-9fdd-3ae165572488.png) |

This also fixes a few accessibility issues with the game board, as before I was using disabled `<button>` elements for empty tiles, even though they can just be `<div>` elements since they are not interactive.