### PR TITLE
Improve Analytics & Add More Policies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "d3": "^7.0.1",
     "focus-trap": "^6.6.1",
     "focus-trap-vue": "3",
     "vue": "^3.0.0",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",
+    "@types/d3": "^7.0.0",
     "@types/mocha": "^5.2.4",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",

--- a/src/classes/simulator.ts
+++ b/src/classes/simulator.ts
@@ -222,7 +222,7 @@ export class Simulator {
 
     // Loop through every year of the simulation and calculate emissions in in
     // that year
-    for (let i = 0; i < totalSimYears; i++) {
+    for (let i = 0; i <= totalSimYears; i++) {
       const currYear = startYear + i;
 
       // If the current year is beyond the option's target year, we've reached

--- a/src/classes/simulator.ts
+++ b/src/classes/simulator.ts
@@ -45,7 +45,9 @@ export interface IPolicyEmissionsWithBreakdown {
  */
 export interface ITotalEmissionsDatum {
   year: number;
-  [tileOptionType: string]: number;
+  deltas: {
+    [tileOptionType: string]: number;
+  }
 }
 
 export interface ITotalEmissionsWithBreakdown {
@@ -307,13 +309,15 @@ export class Simulator {
         if (tileData.length === 0) {
           tileData = optionData.data.map((datum: IPolicyDatum) => ({
             year: datum.year,
-            [tileOption.optionType as string]: datum.delta,
+            deltas: {
+              [tileOption.optionType as string]: datum.delta,
+            }
           }));
         }
         // Otherwise just add this tile option
         else {
           optionData.data.forEach((datum: IPolicyDatum, index: number) => {
-            tileData[index][tileOption.optionType  as string] = datum.delta;
+            tileData[index].deltas[tileOption.optionType  as string] = datum.delta;
           });
         }
       });

--- a/src/classes/tile-obj.ts
+++ b/src/classes/tile-obj.ts
@@ -44,9 +44,8 @@ export class TileObj {
    * its green variant or the default polluting variant. We show the tile as
    * green if the score is > 0.5.
    *
-   * TODO: Enhance this and add unit tests to confirm it works with a variety
-   * of options, as currently this ignores the targetYear and original value
-   * entirely.
+   * This basically is equivalent to an average of the option target values
+   * clamped to 0 - 1. (e.g. targets of 100, 50, and 0 yields 0.5)
    */
   totalGreenScore(): number {
     // Guard against not having options (empty tile)
@@ -56,14 +55,12 @@ export class TileObj {
 
     const optionsArr = Object.values(this.options);
 
-    const optionsCount = optionsArr.length;
-
     let targetTotal = 0;
 
     optionsArr
-      .forEach((opt: IOption) => targetTotal += opt.target);
+      .forEach((opt: IOption) => targetTotal += (opt.target / 100));
 
-    return targetTotal / optionsCount;
+    return targetTotal / optionsArr.length;
   }
 
   /**

--- a/src/components/AnalyticsOverlay.vue
+++ b/src/components/AnalyticsOverlay.vue
@@ -126,6 +126,10 @@ export default class AnalyticsOverlay extends Vue {
 
   tiles: Array<TileObj> = [];
 
+  xScale: any;
+
+  graphMargins = { top: 30, right: 30, bottom: 70, left: 60 };
+
   mounted(): void {
     const currYear = Simulator.getCurrentYear();
 
@@ -138,8 +142,6 @@ export default class AnalyticsOverlay extends Vue {
 
   calculateValues(): void {
     const totalEmissionsData = Simulator.getTotalEmissionsData(this.tiles);
-
-    console.log({ 'totalEmissionsData': totalEmissionsData.data });
 
     this.graphEmissionsOverTime(totalEmissionsData.data);
 
@@ -162,34 +164,33 @@ export default class AnalyticsOverlay extends Vue {
 
   graphEmissionsOverTime(emissionsData: Array<ITotalEmissionsDatum>): void {
     // set the dimensions and margins of the graph
-    const margin = { top: 30, right: 30, bottom: 70, left: 60 };
-    const width = 800 - margin.left - margin.right;
-    const height = 500 - margin.top - margin.bottom;
+    const width = 1000 - this.graphMargins.left - this.graphMargins.right;
+    const height = 300 - this.graphMargins.top - this.graphMargins.bottom;
 
     // append the svg object to the body of the page
     var svg = d3.select('#emissions-chart')
       .append('svg')
-        .attr('width', width + margin.left + margin.right)
-        .attr('height', height + margin.top + margin.bottom)
+        .attr('width', width + this.graphMargins.left + this.graphMargins.right)
+        .attr('height', height + this.graphMargins.top + this.graphMargins.bottom)
       .append('g')
         .attr('transform',
-              'translate(' + margin.left + ',' + margin.top + ')');
+              'translate(' + this.graphMargins.left + ',' + this.graphMargins.top + ')');
 
     // X axis
-    var xScale = d3.scaleBand()
-      .padding(0.2)
+    this.xScale = d3.scaleBand()
       .range([ 0, width ])
       .domain(emissionsData.map((d: ITotalEmissionsDatum) => d.year.toString()));
+
     svg.append('g')
       .attr('transform', 'translate(0,' + height + ')')
-      .call(d3.axisBottom(xScale).tickValues(this.tickYears))
+      .call(d3.axisBottom(this.xScale).tickValues(this.tickYears))
       .selectAll('text')
         .attr('transform', 'translate(-10,0)rotate(-45)')
         .style('text-anchor', 'end');
 
     // Add Y axis
     var yScale = d3.scaleLinear()
-      .domain([0, 100])
+      .domain([0, 55])
       .range([ height, 0]);
     svg.append('g')
       .call(d3.axisLeft(yScale));
@@ -199,11 +200,43 @@ export default class AnalyticsOverlay extends Vue {
       .data(emissionsData)
       .enter()
       .append('rect')
-        .attr('x', (d: ITotalEmissionsDatum) => xScale(d.year.toString()) as number)
-        .attr('y', (d: ITotalEmissionsDatum) => yScale(d3.sum(Object.values(d.deltas)) + OrigYearlyEmissionsGigaTonnes))
-        .attr('width', xScale.bandwidth())
-        .attr('height', (d: ITotalEmissionsDatum) => height - yScale(d3.sum(Object.values(d.deltas)) + OrigYearlyEmissionsGigaTonnes))
-        .attr('fill', '#69b3a2');
+        .attr('class', 'bar')
+        .attr('data-year', (d: ITotalEmissionsDatum) => d.year)
+        .attr('x', (d: ITotalEmissionsDatum) => {
+          return this.xScale(d.year.toString()) as number;
+        })
+        .attr('y', (d: ITotalEmissionsDatum) => yScale(this.emissionsFromDatum(d)))
+        .attr('width', this.xScale.bandwidth())
+        .attr('height', (d: ITotalEmissionsDatum) => height - yScale(this.emissionsFromDatum(d)))
+        .on('click', this.barClick.bind(this));
+
+    d3.select('#emissions-chart')
+      .append('div')
+      .attr('class', 'tooltip');
+  }
+
+  emissionsFromDatum(datum: ITotalEmissionsDatum): number {
+    return d3.sum(Object.values(datum.deltas)) + OrigYearlyEmissionsGigaTonnes;
+  }
+
+  barClick(event: PointerEvent, datum: ITotalEmissionsDatum) {
+    const totalEmissions = this.emissionsFromDatum(datum).toFixed(2);
+
+    const tooltipOffset = 15;
+    const tooltipLeft = this.xScale(datum.year.toString())
+      + this.graphMargins.left
+      + tooltipOffset;
+
+    d3.select('.tooltip')
+      .html(`<h1>${datum.year}</h1> Emissions: ${totalEmissions} Gigatonnes`)
+      .style('left', tooltipLeft + 'px')
+      .classed('-visible', true);
+
+    d3.selectAll('.bar')
+      .classed('-active', false);
+
+    d3.select(`.bar[data-year="${datum.year}"]`)
+      .classed('-active', true);
   }
 }
 </script>
@@ -211,9 +244,55 @@ export default class AnalyticsOverlay extends Vue {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+@import './styles/variables/colors';
 @import './styles/variables/spacing';
 
 h2 { margin-top: $standard; }
+
+figure ::v-deep {
+  position: relative;
+
+  .bar {
+    transition: fill 0.3s;
+    fill: $blue;
+    cursor: pointer;
+    stroke: $white;
+
+    &:hover { fill: $dark-blue; }
+    &.-active { fill: $dark-blue; }
+  }
+
+  .tooltip {
+    position: absolute;
+    padding: $small;
+    bottom: 100px;
+    min-width: 14rem;
+    border-radius: 0.25rem;
+    background-color: $white;
+    border: solid 1px $light-grey;
+    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.5) ;
+    opacity: 0;
+    transition: opacity 0.3s;
+
+    &::before {
+      $tipWidth: 10px;
+
+      position: absolute;
+      display: inline-block;
+      border-top: $tipWidth solid transparent;
+      border-right: $tipWidth solid $white;
+      border-bottom: $tipWidth solid transparent;
+      border-right-color: rgb(255 255 255);
+      left: -$tipWidth;
+      top: 20px;
+      content: "";
+    }
+
+    &.-visible { opacity: 1; }
+
+    h1 { font-size: 1.25rem; }
+  }
+}
 
 dl {
   dt {

--- a/src/components/AnalyticsOverlay.vue
+++ b/src/components/AnalyticsOverlay.vue
@@ -222,15 +222,21 @@ export default class AnalyticsOverlay extends Vue {
   barClick(event: PointerEvent, datum: ITotalEmissionsDatum) {
     const totalEmissions = this.emissionsFromDatum(datum).toFixed(2);
 
-    const tooltipOffset = 15;
+    // Tooltips default to the right, but past 2070 we'll flip it
+    const isTooltipLeft = datum.year >= 2070;
+    const tooltipWidth = (d3.select('.tooltip').node() as HTMLDivElement).offsetWidth;
+
+    const tooltipOffset = 3;
     const tooltipLeft = this.xScale(datum.year.toString())
       + this.graphMargins.left
-      + tooltipOffset;
+      + (isTooltipLeft ? -tooltipWidth : this.xScale.bandwidth())
+      + (isTooltipLeft ? -tooltipOffset : tooltipOffset)
 
     d3.select('.tooltip')
       .html(`<h1>${datum.year}</h1> Emissions: ${totalEmissions} Gigatonnes`)
       .style('left', tooltipLeft + 'px')
-      .classed('-visible', true);
+      .classed('-visible', true)
+      .classed('-left', isTooltipLeft);
 
     d3.selectAll('.bar')
       .classed('-active', false);
@@ -286,6 +292,13 @@ figure ::v-deep {
       left: -$tipWidth;
       top: 20px;
       content: "";
+    }
+
+    &.-left {
+      &::before {
+        left: 100%;
+        transform: rotate(180deg);
+      }
     }
 
     &.-visible { opacity: 1; }

--- a/src/components/AnalyticsOverlay.vue
+++ b/src/components/AnalyticsOverlay.vue
@@ -382,10 +382,28 @@ $officeColor:   #5c76ff;
 $factoryColor:  #bd8d6b;
 $farmColor:     #5cb860;
 
-figure ::v-deep {
+figure {
   position: relative;
 
-  svg { width: 100%; }
+  :deep(svg) {
+    width: 100%;
+
+    .bar-cont {
+      &.-factory rect { fill: $factoryColor; }
+      &.-farm rect { fill: $farmColor; }
+      &.-home rect { fill: $homeColor; }
+      &.-office rect { fill: $officeColor; }
+      &.-power rect { fill: $powerColor; }
+    }
+
+    .bar {
+      transition: filter 0.3s;
+      cursor: pointer;
+      stroke: $white;
+
+      &.-active { filter: brightness(0.7) }
+    }
+  }
 
   .legend-square {
     position: relative;
@@ -403,22 +421,6 @@ figure ::v-deep {
     &.-home { background: $homeColor; }
     &.-office { background: $officeColor; }
     &.-power { background: $powerColor; }
-  }
-
-  .bar-cont {
-    &.-factory rect { fill: $factoryColor; }
-    &.-farm rect { fill: $farmColor; }
-    &.-home rect { fill: $homeColor; }
-    &.-office rect { fill: $officeColor; }
-    &.-power rect { fill: $powerColor; }
-  }
-
-  .bar {
-    transition: filter 0.3s;
-    cursor: pointer;
-    stroke: $white;
-
-    &.-active { filter: brightness(0.7) }
   }
 
   .tooltip {

--- a/src/components/AnalyticsOverlay.vue
+++ b/src/components/AnalyticsOverlay.vue
@@ -120,7 +120,21 @@ export default class AnalyticsOverlay extends Vue {
   SimulatorUnits = SimulatorUnits;
   TempCalcMethod = TempCalcMethod;
 
+  tickYears = [
+    '2020', '2021', '2030', '2040', '2050', '2060', '2070', '2080', '2090', '2100'
+  ];
+
   tiles: Array<TileObj> = [];
+
+  mounted(): void {
+    const currYear = Simulator.getCurrentYear();
+
+    // Filter ticks to only those in present or future
+    this.tickYears = this.tickYears
+      .filter(tick => Number.parseInt(tick) >= currYear);
+
+    this.calculateValues();
+  }
 
   calculateValues(): void {
     const totalEmissionsData = Simulator.getTotalEmissionsData(this.tiles);
@@ -153,47 +167,43 @@ export default class AnalyticsOverlay extends Vue {
     const height = 500 - margin.top - margin.bottom;
 
     // append the svg object to the body of the page
-    var svg = d3.select("#emissions-chart")
-      .append("svg")
-        .attr("width", width + margin.left + margin.right)
-        .attr("height", height + margin.top + margin.bottom)
-      .append("g")
-        .attr("transform",
-              "translate(" + margin.left + "," + margin.top + ")");
+    var svg = d3.select('#emissions-chart')
+      .append('svg')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+        .attr('transform',
+              'translate(' + margin.left + ',' + margin.top + ')');
 
     // X axis
     var xScale = d3.scaleBand()
       .padding(0.2)
       .range([ 0, width ])
       .domain(emissionsData.map((d: ITotalEmissionsDatum) => d.year.toString()));
-    svg.append("g")
-      .attr("transform", "translate(0," + height + ")")
-      .call(d3.axisBottom(xScale))
-      .selectAll("text")
-        .attr("transform", "translate(-10,0)rotate(-45)")
-        .style("text-anchor", "end");
+    svg.append('g')
+      .attr('transform', 'translate(0,' + height + ')')
+      .call(d3.axisBottom(xScale).tickValues(this.tickYears))
+      .selectAll('text')
+        .attr('transform', 'translate(-10,0)rotate(-45)')
+        .style('text-anchor', 'end');
 
     // Add Y axis
     var yScale = d3.scaleLinear()
       .domain([0, 100])
       .range([ height, 0]);
-    svg.append("g")
+    svg.append('g')
       .call(d3.axisLeft(yScale));
 
     // Bars
-    svg.selectAll("mybar")
+    svg.selectAll('mybar')
       .data(emissionsData)
       .enter()
-      .append("rect")
-        .attr("x", (d: ITotalEmissionsDatum) => xScale(d.year.toString()) as number)
-        .attr("y", (d: ITotalEmissionsDatum) => yScale(d3.sum(Object.values(d.deltas)) + OrigYearlyEmissionsGigaTonnes))
-        .attr("width", xScale.bandwidth())
-        .attr("height", (d: ITotalEmissionsDatum) => height - yScale(d3.sum(Object.values(d.deltas)) + OrigYearlyEmissionsGigaTonnes))
-        .attr("fill", "#69b3a2");
-  }
-
-  mounted(): void {
-    this.calculateValues();
+      .append('rect')
+        .attr('x', (d: ITotalEmissionsDatum) => xScale(d.year.toString()) as number)
+        .attr('y', (d: ITotalEmissionsDatum) => yScale(d3.sum(Object.values(d.deltas)) + OrigYearlyEmissionsGigaTonnes))
+        .attr('width', xScale.bandwidth())
+        .attr('height', (d: ITotalEmissionsDatum) => height - yScale(d3.sum(Object.values(d.deltas)) + OrigYearlyEmissionsGigaTonnes))
+        .attr('fill', '#69b3a2');
   }
 }
 </script>

--- a/src/components/SimulatorBoard.vue
+++ b/src/components/SimulatorBoard.vue
@@ -99,7 +99,7 @@ import Thermometer from './Thermometer.vue';
     selectedTile: null,
 
     settings: {
-      magicModeEnabled: true,
+      magicModeEnabled: false,
       customPoliciesEnabled: false,
     } as ISimulatorSettings,
 

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -1,13 +1,19 @@
 <template>
-  <div class="thermometer">
-    <div class="stem">
-      <div class="stem-inner"
-        v-bind:style="{ height: avgTempAdjusted + '%' }"></div>
+  <div class="thermometer-cont">
+    <div class="thermometer">
+      <div class="stem">
+        <div class="stem-inner"
+          v-bind:style="{ height: avgTempAdjusted + '%' }"></div>
+        <div class="tick"></div>
+        <div class="tick"></div>
+        <div class="tick"></div>
+      </div>
+      <div class="bulb"></div>
     </div>
-    <div class="bulb"></div>
 
     <div class="text">
       <div class="temp">{{ avgTempRise.toFixed(2) }} °C</div>
+      <p class="label">{{ $t('simulator.avgTempLabel') }}</p>
 
       <div class="emoji">
         <span v-if="avgTempRise < TempThresholds.great">
@@ -24,7 +30,6 @@
         </span>
       </div>
 
-      <!-- <p class="label">{{ $t('simulator.avgTempLabel') }}</p> -->
     </div>
   </div>
 </template>
@@ -76,6 +81,7 @@ export default class Thermometer extends Vue {
     thermometer. */
   avgTempAdjusted: number = 0;
 
+  // What 100% of the .stem-inner height equates to in degrees
   static readonly MaxTempRise: number = 3;
 
   calculateTemperature(): void {
@@ -96,6 +102,11 @@ export default class Thermometer extends Vue {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
 @import './styles/variables/colors';
+@import './styles/variables/spacing';
+
+.thermometer-cont {
+  margin-top: $large;
+}
 
 .thermometer {
   $thermometer-width: 5rem;
@@ -104,7 +115,7 @@ export default class Thermometer extends Vue {
 
   position: relative;
   width: $thermometer-width;
-  margin-right: 2rem;
+  margin: 0 $standard;
   flex-shrink: 0;
 
   $red: red;
@@ -118,7 +129,7 @@ export default class Thermometer extends Vue {
     position: relative;
     overflow: hidden;
     width: $inner-width + $border-width * 2;
-    height: 85%;
+    height: 25rem;
     margin: auto;
     border-top-left-radius: 2rem;
     border-top-right-radius: 2rem;
@@ -147,23 +158,22 @@ export default class Thermometer extends Vue {
     position: relative;
     top: -1rem;
   }
+}
 
-  .text {
-    text-align: center;
-    font-size: 0.8rem;
-    padding-top: 0.5rem;
+.text {
+  text-align: center;
+  font-size: 0.8rem;
 
-    .emoji {
-      font-size: 2rem;
-      margin-top: 0.5rem;
-    }
-
-    .temp {
-      font-size: 1.25rem;
-      font-weight: bold;
-    }
-
-    .label { margin-top: 0.25rem; }
+  .emoji {
+    font-size: 2.5rem;
+    margin-top: $standard;
   }
+
+  .temp {
+    font-size: 1.25rem;
+    font-weight: bold;
+  }
+
+  .label { margin-top: 0; }
 }
 </style>

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -114,6 +114,9 @@ export default class Tile extends Vue { }
     outline-color: $white;
   }
 
+  // Fade out images on non-interactive tiles so it's clearly not interactive
+  &.-empty .above-ground { opacity: 0.5; }
+
   .above-ground {
     width: 100%;
     height: 100%;

--- a/src/components/TileOverlay.vue
+++ b/src/components/TileOverlay.vue
@@ -280,6 +280,7 @@ export default class TileOverlay extends Vue { }
 
   .policy-card {
     display: flex;
+    flex-wrap: wrap;
     background: $white;
     color: $text-grey;
     padding: $standard;
@@ -344,7 +345,10 @@ export default class TileOverlay extends Vue { }
       }
     }
 
-    .custom-policy-cont { margin-left: 1.25rem; }
+    .custom-policy-cont {
+      margin-left: 1.25rem;
+      width: 100%;
+    }
   }
 }
 

--- a/src/components/TileOverlay.vue
+++ b/src/components/TileOverlay.vue
@@ -69,8 +69,9 @@
                             {{ policyEmissions[policy.key] }} Gigatonnes CO<sub>2</sub>
                           </div>
 
-                          <!-- Only show the description of the current policy -->
-                          <p v-if="option.currPolicyKey === policy.key">
+                          <!-- Only show the description of the current policy,
+                            if it's not "None" -->
+                          <p v-if="option.currPolicyKey === policy.key && policy.key !== TilePolicyKey.None">
                             {{ $t(`simulator.tilePolicies.${policy.key}.description`) }}
                           </p>
                         </div>

--- a/src/constants/tile-options.ts
+++ b/src/constants/tile-options.ts
@@ -51,7 +51,6 @@ export const TileOptions: { [ type: string ]: IOptions } = {
       weightPrcnt: RoadTransportTotalWeight * 0.4,
       policies: TilePolicies[TileOption.FreightRoadTransport]
     }),
-    //
     [TileOption.Shipping]: createOption({
       optionType: TileOption.Shipping,
       weightPrcnt: 1.7,
@@ -62,6 +61,11 @@ export const TileOptions: { [ type: string ]: IOptions } = {
       optionType: TileOption.EnergyIndustry,
       weightPrcnt:  24.2,
       policies: TilePolicies[TileOption.EnergyIndustry]
+    }),
+    [TileOption.DirectIndustrialProcesses]: createOption({
+      optionType: TileOption.DirectIndustrialProcesses,
+      weightPrcnt:  5.2,
+      policies: TilePolicies[TileOption.DirectIndustrialProcesses]
     }),
   },
 
@@ -82,6 +86,21 @@ export const TileOptions: { [ type: string ]: IOptions } = {
       weightPrcnt: 1.7,
       policies: TilePolicies[TileOption.EnergyAgriculture]
     }),
+    [TileOption.Cropland]: createOption({
+      optionType: TileOption.Cropland,
+      weightPrcnt: 1.4,
+      policies: TilePolicies[TileOption.Cropland]
+    }),
+    [TileOption.CropBurning]: createOption({
+      optionType: TileOption.CropBurning,
+      weightPrcnt: 3.5,
+      policies: TilePolicies[TileOption.CropBurning]
+    }),
+    [TileOption.AgriculturalSoils]: createOption({
+      optionType: TileOption.AgriculturalSoils,
+      weightPrcnt: 4.1,
+      policies: TilePolicies[TileOption.AgriculturalSoils]
+    }),
   },
 
   [TileType.Home]: {
@@ -100,8 +119,13 @@ export const TileOptions: { [ type: string ]: IOptions } = {
     // "Energy use in buildings > Residential buildings"
     [TileOption.Aviation]: createOption({
       optionType: TileOption.Aviation,
-      weightPrcnt: 10.9,
+      weightPrcnt: 1.9,
       policies: TilePolicies[TileOption.Aviation]
+    }),
+    [TileOption.Waste]: createOption({
+      optionType: TileOption.Waste,
+      weightPrcnt: 3.2,
+      policies: TilePolicies[TileOption.Waste]
     }),
   },
 

--- a/src/constants/tile-options.ts
+++ b/src/constants/tile-options.ts
@@ -1,15 +1,29 @@
 import { IOption, IOptions, IOptionPolicy, TileType, TileOption } from '../interfaces/tile-interfaces';
-import { TilePolicies, TilePolicyKey } from './tile-policies';
+import {
+  CustomPolicy,
+  NonePolicy,
+  TilePolicies,
+  TilePolicyKey
+} from './tile-policies';
 
-const EmptyOption: IOption = {
-  optionType: null,
+/**
+ * The params we need to create a new option. Everything else comes from the
+ * defaults in DefaultOptionValues
+ */
+interface ICreateOptionParams {
+  tileType: TileType;
+  optionType: TileOption;
+  weightPrcnt: number;
+  policies: Array<IOptionPolicy>;
+}
+
+const DefaultOptionValues = {
   current: 0,
   target: 0,
   targetYear: 2050,
   weightPrcnt: 0,
   currPolicyKey: TilePolicyKey.None,
 };
-
 
 /**
  * # Data I Need
@@ -31,10 +45,20 @@ const EmptyOption: IOption = {
 const RoadTransportTotalWeight = 11.9;
 
 /**
- * Create a new option, using EmptyOption to fill in default values
+ * Create a new option, using DefaultOptionValues to fill in default values
  */
-function createOption(optParams: any): IOption {
-  return Object.assign({}, EmptyOption, optParams);
+function createOption(optParams: ICreateOptionParams): IOption {
+  return Object.assign({}, DefaultOptionValues, optParams);
+}
+
+/**
+ * Get the policies for a certain tile option, ensuring the NonePolicy is added
+ * as the first option and custom is added as the last
+ */
+function getPolicies(policyKey: TileOption): Array<IOptionPolicy> {
+  return [ NonePolicy ]
+    .concat(TilePolicies[policyKey])
+    .concat([ CustomPolicy ]);
 }
 
 /**
@@ -47,94 +71,109 @@ export const TileOptions: { [ type: string ]: IOptions } = {
   [TileType.Factory]: {
     // "Transport > Road transport" * 40% commercial
     [TileOption.FreightRoadTransport]: createOption({
+      tileType: TileType.Factory,
       optionType: TileOption.FreightRoadTransport,
       weightPrcnt: RoadTransportTotalWeight * 0.4,
-      policies: TilePolicies[TileOption.FreightRoadTransport]
+      policies: getPolicies(TileOption.FreightRoadTransport)
     }),
     [TileOption.Shipping]: createOption({
+      tileType: TileType.Factory,
       optionType: TileOption.Shipping,
       weightPrcnt: 1.7,
-      policies: TilePolicies[TileOption.Shipping]
+      policies: getPolicies(TileOption.Shipping)
     }),
     // This comes from "Energy use in industry"
     [TileOption.EnergyIndustry]: createOption({
+      tileType: TileType.Factory,
       optionType: TileOption.EnergyIndustry,
       weightPrcnt:  24.2,
-      policies: TilePolicies[TileOption.EnergyIndustry]
+      policies: getPolicies(TileOption.EnergyIndustry)
     }),
     [TileOption.DirectIndustrialProcesses]: createOption({
+      tileType: TileType.Factory,
       optionType: TileOption.DirectIndustrialProcesses,
       weightPrcnt:  5.2,
-      policies: TilePolicies[TileOption.DirectIndustrialProcesses]
+      policies: getPolicies(TileOption.DirectIndustrialProcesses)
     }),
   },
 
   [TileType.Farm]: {
     [TileOption.LivestockAndManure]: createOption({
+      tileType: TileType.Farm,
       optionType: TileOption.LivestockAndManure,
       weightPrcnt: 5.8,
-      policies: TilePolicies[TileOption.LivestockAndManure]
+      policies: getPolicies(TileOption.LivestockAndManure)
     }),
     [TileOption.Deforestation]: createOption({
+      tileType: TileType.Farm,
       optionType: TileOption.Deforestation,
       weightPrcnt: 2.2,
-      policies: TilePolicies[TileOption.Deforestation]
+      policies: getPolicies(TileOption.Deforestation)
     }),
     // Called "Energy use in agriculture and fishing"
     [TileOption.EnergyAgriculture]: createOption({
+      tileType: TileType.Farm,
       optionType: TileOption.EnergyAgriculture,
       weightPrcnt: 1.7,
-      policies: TilePolicies[TileOption.EnergyAgriculture]
+      policies: getPolicies(TileOption.EnergyAgriculture)
     }),
     [TileOption.Cropland]: createOption({
+      tileType: TileType.Farm,
       optionType: TileOption.Cropland,
       weightPrcnt: 1.4,
-      policies: TilePolicies[TileOption.Cropland]
+      policies: getPolicies(TileOption.Cropland)
     }),
     [TileOption.CropBurning]: createOption({
+      tileType: TileType.Farm,
       optionType: TileOption.CropBurning,
       weightPrcnt: 3.5,
-      policies: TilePolicies[TileOption.CropBurning]
+      policies: getPolicies(TileOption.CropBurning)
     }),
     [TileOption.AgriculturalSoils]: createOption({
+      tileType: TileType.Farm,
       optionType: TileOption.AgriculturalSoils,
       weightPrcnt: 4.1,
-      policies: TilePolicies[TileOption.AgriculturalSoils]
+      policies: getPolicies(TileOption.AgriculturalSoils)
     }),
   },
 
   [TileType.Home]: {
     // "Transport > Road transport" * 60% passenger
     [TileOption.PassengerRoadTransport]: createOption({
+      tileType: TileType.Home,
       optionType: TileOption.PassengerRoadTransport,
       weightPrcnt: RoadTransportTotalWeight * 0.6,
-      policies: TilePolicies[TileOption.PassengerRoadTransport]
+      policies: getPolicies(TileOption.PassengerRoadTransport)
     }),
     // "Energy use in buildings > Residential buildings"
     [TileOption.EnergyResidential]: createOption({
+      tileType: TileType.Home,
       optionType: TileOption.EnergyResidential,
       weightPrcnt: 10.9,
-      policies: TilePolicies[TileOption.EnergyResidential]
+      policies: getPolicies(TileOption.EnergyResidential)
     }),
     // "Energy use in buildings > Residential buildings"
     [TileOption.Aviation]: createOption({
+      tileType: TileType.Home,
       optionType: TileOption.Aviation,
       weightPrcnt: 1.9,
-      policies: TilePolicies[TileOption.Aviation]
+      policies: getPolicies(TileOption.Aviation)
     }),
     [TileOption.Waste]: createOption({
+      tileType: TileType.Home,
       optionType: TileOption.Waste,
       weightPrcnt: 3.2,
-      policies: TilePolicies[TileOption.Waste]
+      policies: getPolicies(TileOption.Waste)
     }),
   },
 
   [TileType.Office]: {
     // "Energy use in buildings > Commercial buildings"
     [TileOption.EnergyCommercialBuildings]: createOption({
+      tileType: TileType.Office,
       optionType: TileOption.EnergyCommercialBuildings,
       weightPrcnt: 6.6,
-      policies: TilePolicies[TileOption.EnergyCommercialBuildings]
+      policies: getPolicies(TileOption.EnergyCommercialBuildings)
     }),
   },
 
@@ -143,14 +182,16 @@ export const TileOptions: { [ type: string ]: IOptions } = {
   // (home tile)
   [TileType.Power]: {
     [TileOption.FugitiveEmissions]: createOption({
+      tileType: TileType.Power,
       optionType: TileOption.FugitiveEmissions,
       weightPrcnt: 5.8,
-      policies: TilePolicies[TileOption.FugitiveEmissions]
+      policies: getPolicies(TileOption.FugitiveEmissions)
     }),
     [TileOption.UnallocatedFuelCombustion]: createOption({
+      tileType: TileType.Power,
       optionType: TileOption.UnallocatedFuelCombustion,
       weightPrcnt: 7.8,
-      policies: TilePolicies[TileOption.UnallocatedFuelCombustion]
+      policies: getPolicies(TileOption.UnallocatedFuelCombustion)
     }),
   },
 };

--- a/src/constants/tile-policies.ts
+++ b/src/constants/tile-policies.ts
@@ -21,16 +21,18 @@ export enum TilePolicyKey {
   FactoryShippingElectricRequirement2050 = 'FactoryShippingElectricRequirement2050',
   FactoryRenewableEnergyRequirement2050 = 'FactoryRenewableEnergyRequirement2050',
   FactoryRenewableEnergyMagic = 'FactoryRenewableEnergyMagic',
-  // DirectIndustrialProcesses
+  FactoryDIPReduction = 'FactoryDIPReduction',
 
   // Farm tile policies
   FarmManureManagement2050 = 'FarmManureManagement',
   FarmDeforestationElimination2050 = 'FarmDeforestationElimination2050',
   FarmRenewableEnergyRequirement2050 = 'FarmRenewableEnergyRequirement2050',
   FarmRenewableEnergyMagic = 'FarmRenewableEnergyMagic',
-  // AgriculturalSoils
-  // Cropland
-  // CropBurning
+  FarmAgriculturalSoilReducedFertilizer = 'FarmAgriculturalSoilReducedFertilizer',
+  FarmAgriculturalSoilNoFertilizer = 'FarmAgriculturalSoilNoFertilizer',
+  FarmCroplandManagement = 'FarmCroplandManagement',
+  FarmCropBurningReduction = 'FarmCropBurningReduction',
+  FarmCropBurningBan = 'FarmCropBurningBan',
 
   // Home tile policies
   HomeElectricVehicleRequirement2050 = 'HomeElectricVehicleRequirement2050',
@@ -41,7 +43,7 @@ export enum TilePolicyKey {
   HomeRenewableEnergyMagic = 'HomeRenewableEnergyMagic',
   HomeAirTravelIncentive = 'HomeAirTravelIncentive',
   HomeAirTravelMagic = 'HomeAirTravelMagic',
-  // Waste
+  HomeWasteManagement = 'HomeWasteManagement',
 
   // Office tile policies
   OfficeRenewableEnergyRequirement2050 = 'OfficeRenewableEnergyRequirement2050',
@@ -85,13 +87,13 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   [TileOption.FreightRoadTransport]: [
     NonePolicy,
     {
-      key: TilePolicyKey.FactoryElectricFreightRequirement2050,
-      target: 100,
+      key: TilePolicyKey.FactoryElectricFreightIncentive,
+      target: 50,
       targetYear: 2050,
     },
     {
-      key: TilePolicyKey.FactoryElectricFreightIncentive,
-      target: 50,
+      key: TilePolicyKey.FactoryElectricFreightRequirement2050,
+      target: 100,
       targetYear: 2050,
     },
     {
@@ -128,6 +130,11 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   ],
   [TileOption.DirectIndustrialProcesses]: [
     NonePolicy,
+    {
+      key: TilePolicyKey.FactoryDIPReduction,
+      target: 70,
+      targetYear: 2050,
+    }
   ],
 
   // Farm options
@@ -166,25 +173,50 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   ],
   [TileOption.Cropland]: [
     NonePolicy,
+    {
+      key: TilePolicyKey.FarmCroplandManagement,
+      target: 100,
+      targetYear: 2050,
+    },
   ],
   [TileOption.CropBurning]: [
     NonePolicy,
+    {
+      key: TilePolicyKey.FarmCropBurningReduction,
+      target: 50,
+      targetYear: 2050,
+    },
+    {
+      key: TilePolicyKey.FarmCropBurningBan,
+      target: 100,
+      targetYear: 2050,
+    }
   ],
   [TileOption.AgriculturalSoils]: [
     NonePolicy,
+    {
+      key: TilePolicyKey.FarmAgriculturalSoilReducedFertilizer,
+      target: 50,
+      targetYear: 2050,
+    },
+    {
+      key: TilePolicyKey.FarmAgriculturalSoilNoFertilizer,
+      target: 100,
+      targetYear: 2050,
+    }
   ],
 
   // Home options
   [TileOption.PassengerRoadTransport]: [
     NonePolicy,
     {
-      key: TilePolicyKey.HomeElectricVehicleRequirement2050,
-      target: 100,
+      key: TilePolicyKey.HomeElectricVehicleIncentive,
+      target: 50,
       targetYear: 2050,
     },
     {
-      key: TilePolicyKey.HomeElectricVehicleIncentive,
-      target: 50,
+      key: TilePolicyKey.HomeElectricVehicleRequirement2050,
+      target: 100,
       targetYear: 2050,
     },
     {
@@ -198,13 +230,13 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   [TileOption.EnergyResidential]: [
     NonePolicy,
     {
-      key: TilePolicyKey.HomeRenewableEnergyRequirement2050,
-      target: 100,
+      key: TilePolicyKey.HomeRenewableEnergyIncentive,
+      target: 50,
       targetYear: 2050,
     },
     {
-      key: TilePolicyKey.HomeRenewableEnergyIncentive,
-      target: 50,
+      key: TilePolicyKey.HomeRenewableEnergyRequirement2050,
+      target: 100,
       targetYear: 2050,
     },
     {
@@ -232,19 +264,24 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   ],
   [TileOption.Waste]: [
     NonePolicy,
+    {
+      key: TilePolicyKey.HomeWasteManagement,
+      target: 80,
+      targetYear: 2050,
+    }
   ],
 
   // Office options
   [TileOption.EnergyCommercialBuildings]: [
     NonePolicy,
     {
-      key: TilePolicyKey.OfficeRenewableEnergyRequirement2050,
-      target: 100,
+      key: TilePolicyKey.OfficeRenewableEnergyIncentive,
+      target: 50,
       targetYear: 2050,
     },
     {
-      key: TilePolicyKey.OfficeRenewableEnergyIncentive,
-      target: 50,
+      key: TilePolicyKey.OfficeRenewableEnergyRequirement2050,
+      target: 100,
       targetYear: 2050,
     },
     {
@@ -260,13 +297,13 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   [TileOption.FugitiveEmissions]: [
     NonePolicy,
     {
-      key: TilePolicyKey.PowerFugitiveEmissionsBan2050,
-      target: 100,
+      key: TilePolicyKey.PowerFugitiveEmissionsClampDown,
+      target: 50,
       targetYear: 2050,
     },
     {
-      key: TilePolicyKey.PowerFugitiveEmissionsClampDown,
-      target: 50,
+      key: TilePolicyKey.PowerFugitiveEmissionsBan2050,
+      target: 100,
       targetYear: 2050,
     },
     CustomPolicy,

--- a/src/constants/tile-policies.ts
+++ b/src/constants/tile-policies.ts
@@ -85,7 +85,6 @@ export const CustomPolicy: IOptionPolicy = {
 export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   // Factory options
   [TileOption.FreightRoadTransport]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FactoryElectricFreightIncentive,
       target: 50,
@@ -102,19 +101,15 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: CurrentYear,
       isMagic: true,
     },
-    CustomPolicy,
   ],
   [TileOption.Shipping]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FactoryShippingElectricRequirement2050,
       target: 100,
       targetYear: 2050,
     },
-    CustomPolicy,
   ],
   [TileOption.EnergyIndustry]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FactoryRenewableEnergyRequirement2050,
       target: 100,
@@ -126,10 +121,8 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: CurrentYear,
       isMagic: true,
     },
-    CustomPolicy,
   ],
   [TileOption.DirectIndustrialProcesses]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FactoryDIPReduction,
       target: 70,
@@ -139,25 +132,20 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
 
   // Farm options
   [TileOption.LivestockAndManure]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FarmManureManagement2050,
       target: 50,
       targetYear: 2050,
     },
-    CustomPolicy,
   ],
   [TileOption.Deforestation]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FarmDeforestationElimination2050,
       target: 100,
       targetYear: 2050,
     },
-    CustomPolicy,
   ],
   [TileOption.EnergyAgriculture]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FarmRenewableEnergyRequirement2050,
       target: 100,
@@ -169,10 +157,8 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: CurrentYear,
       isMagic: true,
     },
-    CustomPolicy,
   ],
   [TileOption.Cropland]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FarmCroplandManagement,
       target: 100,
@@ -180,7 +166,6 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
     },
   ],
   [TileOption.CropBurning]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FarmCropBurningReduction,
       target: 50,
@@ -193,7 +178,6 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
     }
   ],
   [TileOption.AgriculturalSoils]: [
-    NonePolicy,
     {
       key: TilePolicyKey.FarmAgriculturalSoilReducedFertilizer,
       target: 50,
@@ -208,7 +192,6 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
 
   // Home options
   [TileOption.PassengerRoadTransport]: [
-    NonePolicy,
     {
       key: TilePolicyKey.HomeElectricVehicleIncentive,
       target: 50,
@@ -225,10 +208,8 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: CurrentYear,
       isMagic: true,
     },
-    CustomPolicy,
   ],
   [TileOption.EnergyResidential]: [
-    NonePolicy,
     {
       key: TilePolicyKey.HomeRenewableEnergyIncentive,
       target: 50,
@@ -245,10 +226,8 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: CurrentYear,
       isMagic: true,
     },
-    CustomPolicy,
   ],
   [TileOption.Aviation]: [
-    NonePolicy,
     {
       key: TilePolicyKey.HomeAirTravelIncentive,
       target: 50,
@@ -260,10 +239,8 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: CurrentYear,
       isMagic: true,
     },
-    CustomPolicy,
   ],
   [TileOption.Waste]: [
-    NonePolicy,
     {
       key: TilePolicyKey.HomeWasteManagement,
       target: 80,
@@ -273,7 +250,6 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
 
   // Office options
   [TileOption.EnergyCommercialBuildings]: [
-    NonePolicy,
     {
       key: TilePolicyKey.OfficeRenewableEnergyIncentive,
       target: 50,
@@ -290,12 +266,10 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: CurrentYear,
       isMagic: true,
     },
-    CustomPolicy,
   ],
 
   // Power options
   [TileOption.FugitiveEmissions]: [
-    NonePolicy,
     {
       key: TilePolicyKey.PowerFugitiveEmissionsClampDown,
       target: 50,
@@ -306,15 +280,12 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       target: 100,
       targetYear: 2050,
     },
-    CustomPolicy,
   ],
   [TileOption.UnallocatedFuelCombustion]: [
-    NonePolicy,
     {
       key: TilePolicyKey.PowerUnallocatedFuelReduction2050,
       target: 50,
       targetYear: 2050,
     },
-    CustomPolicy,
   ],
 }

--- a/src/constants/tile-policies.ts
+++ b/src/constants/tile-policies.ts
@@ -21,12 +21,16 @@ export enum TilePolicyKey {
   FactoryShippingElectricRequirement2050 = 'FactoryShippingElectricRequirement2050',
   FactoryRenewableEnergyRequirement2050 = 'FactoryRenewableEnergyRequirement2050',
   FactoryRenewableEnergyMagic = 'FactoryRenewableEnergyMagic',
+  // DirectIndustrialProcesses
 
   // Farm tile policies
   FarmManureManagement2050 = 'FarmManureManagement',
   FarmDeforestationElimination2050 = 'FarmDeforestationElimination2050',
   FarmRenewableEnergyRequirement2050 = 'FarmRenewableEnergyRequirement2050',
   FarmRenewableEnergyMagic = 'FarmRenewableEnergyMagic',
+  // AgriculturalSoils
+  // Cropland
+  // CropBurning
 
   // Home tile policies
   HomeElectricVehicleRequirement2050 = 'HomeElectricVehicleRequirement2050',
@@ -37,6 +41,7 @@ export enum TilePolicyKey {
   HomeRenewableEnergyMagic = 'HomeRenewableEnergyMagic',
   HomeAirTravelIncentive = 'HomeAirTravelIncentive',
   HomeAirTravelMagic = 'HomeAirTravelMagic',
+  // Waste
 
   // Office tile policies
   OfficeRenewableEnergyRequirement2050 = 'OfficeRenewableEnergyRequirement2050',
@@ -121,6 +126,9 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
     },
     CustomPolicy,
   ],
+  [TileOption.DirectIndustrialProcesses]: [
+    NonePolicy,
+  ],
 
   // Farm options
   [TileOption.LivestockAndManure]: [
@@ -155,6 +163,15 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       isMagic: true,
     },
     CustomPolicy,
+  ],
+  [TileOption.Cropland]: [
+    NonePolicy,
+  ],
+  [TileOption.CropBurning]: [
+    NonePolicy,
+  ],
+  [TileOption.AgriculturalSoils]: [
+    NonePolicy,
   ],
 
   // Home options
@@ -212,6 +229,9 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       isMagic: true,
     },
     CustomPolicy,
+  ],
+  [TileOption.Waste]: [
+    NonePolicy,
   ],
 
   // Office options

--- a/src/interfaces/tile-interfaces.ts
+++ b/src/interfaces/tile-interfaces.ts
@@ -131,7 +131,16 @@ export interface IOptionPolicy {
  * buttons for "100% Renewable by 2050", "50% Renewable by 2040", etc.
  */
 export interface IOption extends IWeightedPolicy {
-  optionType: TileOption | null;
+  /**
+   * The type of this option
+   */
+  optionType: TileOption;
+
+  /**
+   * The type of tile this corresponds to - useful for aggregating back a set
+   * of options back to their corresponding types
+   */
+  tileType: TileType;
 
   /**
    * A percentage (0 - 100) representing the current value of this option.

--- a/src/interfaces/tile-interfaces.ts
+++ b/src/interfaces/tile-interfaces.ts
@@ -36,18 +36,23 @@ export enum TileType {
  * sure that the language files are updated along with this enum!
  */
 export enum TileOption {
+  AgriculturalSoils = 'agriculturalSoils',
   Aviation = 'aviation',
-  FreightRoadTransport = 'freightRoadTransport',
+  CropBurning = 'cropBurning',
+  Cropland = 'cropland',
   Deforestation = 'deforestation',
+  DirectIndustrialProcesses = 'directIndustrialProcesses',
   EnergyAgriculture = 'energyAgriculture',
   EnergyCommercialBuildings = 'energyCommercialBuildings',
   EnergyIndustry = 'energyIndustry',
   EnergyResidential = 'energyResidential',
+  FreightRoadTransport = 'freightRoadTransport',
   FugitiveEmissions = 'fugitiveEmissions',
   LivestockAndManure = 'livestockAndManure',
   PassengerRoadTransport = 'passengerRoadTransport',
   Shipping = 'shipping',
   UnallocatedFuelCombustion = 'unallocatedFuelCombustion',
+  Waste = 'waste',
 }
 
 /**

--- a/src/locales/english.ts
+++ b/src/locales/english.ts
@@ -104,15 +104,15 @@ export const EnglishLanguageData: ILanguageData = {
       },
 
       // Factory policies
-      [TilePolicyKey.FactoryElectricFreightRequirement2050]: {
-        name: 'Require All Electric Freight by 2050',
-        description:
-          'Require all road freight vehicles to be electric by 2050.',
-      },
       [TilePolicyKey.FactoryElectricFreightIncentive]: {
         name: 'Electric Freight Incentives',
         description:
           'Provide tax incentives for electric freight vehicles, cutting gas powered trucks in half by 2050.',
+      },
+      [TilePolicyKey.FactoryElectricFreightRequirement2050]: {
+        name: 'Require All Electric Freight by 2050',
+        description:
+          'Require all road freight vehicles to be electric by 2050.',
       },
       [TilePolicyKey.FactoryElectricFreightMagic]: {
         name: 'Instant Electric Freight Conversion',
@@ -132,6 +132,10 @@ export const EnglishLanguageData: ILanguageData = {
         name: 'Instantly Convert Industry to Green Energy',
         description: 'Instantly switch all power sources for industry to renewables.',
       },
+      [TilePolicyKey.FactoryDIPReduction]: {
+        name: 'Greener Industrial Processes',
+        description:  'Use new methods for industrial processes like creating cement to cut emissions by 70% by 2050',
+      },
 
       // Farm policies
       [TilePolicyKey.FarmManureManagement2050]: {
@@ -150,27 +154,47 @@ export const EnglishLanguageData: ILanguageData = {
         name: 'Instantly Convert Agriculture to Green Energy',
         description: 'Instantly switch farms to run completely off of renewable energy.',
       },
+      [TilePolicyKey.FarmAgriculturalSoilReducedFertilizer]: {
+        name: 'Reduced Fertilizer',
+        description: 'Reduce Nitrous Oxide emissions by requiring reduced fertilizer use',
+      },
+      [TilePolicyKey.FarmAgriculturalSoilNoFertilizer]: {
+        name: 'Artificial Fertilizer Ban by 2050',
+        description: 'Stop Nitrous Oxide emissions from agriculture by completely banning aritifial fertilizers by 2050.',
+      },
+      [TilePolicyKey.FarmCroplandManagement]: {
+        name: 'Farm Cropland Management',
+        description: 'Improve techniques for manging cropland to ensure soils retain all their carbon by 2050',
+      },
+      [TilePolicyKey.FarmCropBurningReduction]: {
+        name: 'Reduced Crop Burning',
+        description: 'Enact policies to reduce crop burning by 50% by 2050',
+      },
+      [TilePolicyKey.FarmCropBurningBan]: {
+        name: 'Ban on Crop Burning',
+        description: 'Completely ban crop burning by 2050, completely eliminating those emissions.',
+      },
 
       // Home policies
-      [TilePolicyKey.HomeElectricVehicleRequirement2050]: {
-        name: 'Electric Vehicle Requirement by 2050',
-        description: 'Phase out gas powered vehicles to get to all passenger vehicles being electric by 2050.',
-      },
       [TilePolicyKey.HomeElectricVehicleIncentive]: {
         name: 'Tax Incentives for Electric Vehicles',
         description: 'Provide tax incentives and subsidies for electric vehicles to cut gas powered vehicles in half by 2050.',
+      },
+      [TilePolicyKey.HomeElectricVehicleRequirement2050]: {
+        name: 'Electric Vehicle Requirement by 2050',
+        description: 'Phase out gas powered vehicles to get to all passenger vehicles being electric by 2050.',
       },
       [TilePolicyKey.HomeElectricVehicleMagic]: {
         name: 'Instantly Electrify All Passenger Vehicles',
         description: 'Using a global transmutation spell, all personal vehicles instantly become electric, with zero emissions!',
       },
-      [TilePolicyKey.HomeRenewableEnergyRequirement2050]: {
-        name: 'Require Green Energy for Homes by 2050',
-        description: 'Require homes to run on fully renewable energy by 2050.',
-      },
       [TilePolicyKey.HomeRenewableEnergyIncentive]: {
         name: 'Renewable Energy Incentive for Homes',
         description: 'Provide incentives and subsidies to halve emissions from home energy by 2050.',
+      },
+      [TilePolicyKey.HomeRenewableEnergyRequirement2050]: {
+        name: 'Require Green Energy for Homes by 2050',
+        description: 'Require homes to run on fully renewable energy by 2050.',
       },
       [TilePolicyKey.HomeRenewableEnergyMagic]: {
         name: 'Instantly Convert Homes to Green Energy',
@@ -184,15 +208,19 @@ export const EnglishLanguageData: ILanguageData = {
         name: 'Instantly Electrify Air Travel',
         description: 'By training a fleet of levitation wizards, make all planes run emission free.',
       },
+      [TilePolicyKey.HomeWasteManagement]: {
+        name: 'Greener Waste Management',
+        description: 'Improve management of waste (including landfills and waste water) to reduce emissions 80% by 2050',
+      },
 
       // Office policies
-      [TilePolicyKey.OfficeRenewableEnergyRequirement2050]: {
-        name: 'Require Green Energy for Offices by 2050',
-        description: 'Require office buildings to run on fully renewable energy by 2050.',
-      },
       [TilePolicyKey.OfficeRenewableEnergyIncentive]: {
         name: 'Renewable Energy Incentives for Offices',
         description: 'Provide tax incentives to cut emissions from office energy in half by 2050.',
+      },
+      [TilePolicyKey.OfficeRenewableEnergyRequirement2050]: {
+        name: 'Require Green Energy for Offices by 2050',
+        description: 'Require office buildings to run on fully renewable energy by 2050.',
       },
       [TilePolicyKey.OfficeRenewableEnergyMagic]: {
         name: 'Instantly Convert Offices to Green Energy',
@@ -200,17 +228,17 @@ export const EnglishLanguageData: ILanguageData = {
       },
 
       // Power policies
-      [TilePolicyKey.PowerFugitiveEmissionsBan2050]: {
-        name: 'Fossil Fuel Extraction Ban by 2050',
-        description: 'Reduce fossil fuel extraction culminating in a ban by 2050, fully reducing fugitive emissions by 2050.',
-      },
       [TilePolicyKey.PowerFugitiveEmissionsClampDown]: {
         name: 'Fugitive Emissions Clampdown',
         description: 'Clamp down on fugitive emissions from fossil fuel production, halving related emissions by 2050.',
       },
+      [TilePolicyKey.PowerFugitiveEmissionsBan2050]: {
+        name: 'Fossil Fuel Extraction Ban by 2050',
+        description: 'Reduce fossil fuel extraction culminating in a ban by 2050, fully reducing fugitive emissions by 2050.',
+      },
       [TilePolicyKey.PowerUnallocatedFuelReduction2050]: {
         name: 'Reduce Unallocated Fuel Emissions',
-        description: 'Use tax incentives and subsidies to reduce emissions from home heating and other unallocated sources',
+        description: 'Use tax incentives and subsidies to cut emissions from home heating and other unallocated sources in half by 2050.',
       },
     }
   }

--- a/src/locales/english.ts
+++ b/src/locales/english.ts
@@ -30,7 +30,7 @@ export const EnglishLanguageData: ILanguageData = {
   },
 
   simulator: {
-    avgTempLabel: 'Avg. Global Increase by 2100',
+    avgTempLabel: 'Warming by 2100',
     close: 'Close',
     analytics: 'Analytics',
     settings: 'Settings',

--- a/src/locales/english.ts
+++ b/src/locales/english.ts
@@ -39,7 +39,7 @@ export const EnglishLanguageData: ILanguageData = {
       current: 'Current',
       target: 'Target Emissions Reduction',
       targetYear: 'Target Year',
-      emissionPrcntLabel: 'orig.',
+      emissionPrcntLabel: 'of',
       policiesLabel: 'Policy',
     },
 

--- a/src/locales/english.ts
+++ b/src/locales/english.ts
@@ -1,4 +1,5 @@
 import { ILanguageData } from '@/interfaces/language-data';
+import { TileOption } from '@/interfaces/tile-interfaces';
 import { TilePolicyKey } from '@/constants/tile-policies';
 
 export const EnglishLanguageData: ILanguageData = {
@@ -71,26 +72,30 @@ export const EnglishLanguageData: ILanguageData = {
 
     // Should include all values from the TileOption enum
     tileOptionTitles: {
-      aviation: 'Aviation',
-      deforestation: 'Deforestation',
-      energyAgriculture: 'Energy for Agriculture',
-      energyCommercialBuildings: 'Energy for Commercial Buildings',
-      energyIndustry: 'Energy for Industry',
-      energyResidential: 'Energy for Residential Buildings',
-      freightRoadTransport: 'Freight Trucking',
-      fugitiveEmissions: 'Fugitive Emissions from Energy Production',
-      livestockAndManure: 'Livestock and Manure',
-      passengerRoadTransport: 'Passenger Vehicles',
-      shipping: 'Shipping',
-      unallocatedFuelCombustion: 'Unallocated Fuel Combustion',
+      [TileOption.Aviation]: 'Aviation',
+      [TileOption.Deforestation]: 'Deforestation',
+      [TileOption.EnergyAgriculture]: 'Energy for Agriculture',
+      [TileOption.EnergyCommercialBuildings]: 'Energy for Commercial Buildings',
+      [TileOption.EnergyIndustry]: 'Energy for Industry',
+      [TileOption.EnergyResidential]: 'Energy for Residential Buildings',
+      [TileOption.FreightRoadTransport]: 'Freight Trucking',
+      [TileOption.FugitiveEmissions]: 'Fugitive Emissions from Energy Production',
+      [TileOption.LivestockAndManure]: 'Livestock and Manure',
+      [TileOption.PassengerRoadTransport]: 'Passenger Vehicles',
+      [TileOption.Shipping]: 'Shipping',
+      [TileOption.UnallocatedFuelCombustion]: 'Unallocated Fuel Combustion',
+      [TileOption.AgriculturalSoils]: 'Agricultural Soils',
+      [TileOption.CropBurning]: 'Crop Burning',
+      [TileOption.Cropland]: 'Cropland',
+      [TileOption.DirectIndustrialProcesses]: 'Direct Industrial Processes',
+      [TileOption.Waste]: 'Waste',
     },
 
     // Should contain all values from TilePolicyKey
     tilePolicies: {
       [TilePolicyKey.None]: {
         name: 'None',
-        description:
-          'Keep related emissions the same for the forseable future.',
+        description: '',
       },
       [TilePolicyKey.Custom]: {
         name: 'Custom',

--- a/src/locales/spanish.ts
+++ b/src/locales/spanish.ts
@@ -39,7 +39,7 @@ export const SpanishLanguageData: ILanguageData = {
       current: 'Actual',
       target: 'Objetivo',
       targetYear: 'Año objetivo',
-      emissionPrcntLabel: 'orig.',
+      emissionPrcntLabel: 'de.',
       policiesLabel: '',
     },
 

--- a/src/locales/spanish.ts
+++ b/src/locales/spanish.ts
@@ -127,6 +127,10 @@ export const SpanishLanguageData: ILanguageData = {
         name: '',
         description: '',
       },
+      [TilePolicyKey.FactoryDIPReduction]: {
+        name: '',
+        description:  '',
+      },
 
       // Farm policies
       [TilePolicyKey.FarmManureManagement2050]: {
@@ -145,6 +149,27 @@ export const SpanishLanguageData: ILanguageData = {
         name: '',
         description: '',
       },
+      [TilePolicyKey.FarmAgriculturalSoilReducedFertilizer]: {
+        name: '',
+        description: '',
+      },
+      [TilePolicyKey.FarmAgriculturalSoilNoFertilizer]: {
+        name: '',
+        description: '',
+      },
+      [TilePolicyKey.FarmCroplandManagement]: {
+        name: '',
+        description: '',
+      },
+      [TilePolicyKey.FarmCropBurningReduction]: {
+        name: '',
+        description: '',
+      },
+      [TilePolicyKey.FarmCropBurningBan]: {
+        name: '',
+        description: '',
+      },
+
 
       // Home policies
       [TilePolicyKey.HomeElectricVehicleRequirement2050]: {
@@ -176,6 +201,10 @@ export const SpanishLanguageData: ILanguageData = {
         description: '',
       },
       [TilePolicyKey.HomeAirTravelMagic]: {
+        name: '',
+        description: '',
+      },
+      [TilePolicyKey.HomeWasteManagement]: {
         name: '',
         description: '',
       },

--- a/src/locales/spanish.ts
+++ b/src/locales/spanish.ts
@@ -1,4 +1,5 @@
 import { ILanguageData } from '@/interfaces/language-data';
+import { TileOption } from '@/interfaces/tile-interfaces';
 import { TilePolicyKey } from '@/constants/tile-policies';
 
 export const SpanishLanguageData: ILanguageData = {
@@ -68,20 +69,23 @@ export const SpanishLanguageData: ILanguageData = {
     },
     // Should include all values from the TileOption enum
     tileOptionTitles: {
-      // TODO: Fill these out
-      aviation: '',
-      commercialRoadTransport: '',
-      deforestation: '',
-      energyAgriculture: '',
-      energyCommercialBuildings: '',
-      energyIndustry: '',
-      energyResidential: '',
-      freightRoadTransport: '',
-      fugitiveEmissions: '',
-      livestockAndManure: '',
-      passengerRoadTransport: '',
-      shipping: '',
-      unallocatedFuelCombustion: '',
+      [TileOption.Aviation]: 'Aviación',
+      [TileOption.Deforestation]: 'Deforestación',
+      [TileOption.EnergyAgriculture]: 'Energía para la agricultura',
+      [TileOption.EnergyCommercialBuildings]: 'Energía para edificios comerciales',
+      [TileOption.EnergyIndustry]: 'Energía para la industria',
+      [TileOption.EnergyResidential]: 'Energía para edificios residenciales',
+      [TileOption.FreightRoadTransport]: 'Transporte de mercancías',
+      [TileOption.FugitiveEmissions]: 'Emisiones fugitivas de la producción de energía',
+      [TileOption.LivestockAndManure]: 'Ganadería y estiércol',
+      [TileOption.PassengerRoadTransport]: 'Vehículos de pasajeros',
+      [TileOption.Shipping]: 'Envío',
+      [TileOption.UnallocatedFuelCombustion]: 'Combustión de combustible no asignado',
+      [TileOption.AgriculturalSoils]: 'Suelos agrícolas',
+      [TileOption.CropBurning]: 'Quema de cultivos',
+      [TileOption.Cropland]: 'Tierras de cultivo',
+      [TileOption.DirectIndustrialProcesses]: 'Procesos industriales directos',
+      [TileOption.Waste]: 'Residuos',
     },
 
     // Should contain all values from TilePolicyKey

--- a/src/views/FAQ.vue
+++ b/src/views/FAQ.vue
@@ -9,7 +9,7 @@
         Carbon Challenge.
       </p>
 
-      <ul>
+      <ul class="bulleted">
         <li>
 
         </li>

--- a/src/views/TakeAction.vue
+++ b/src/views/TakeAction.vue
@@ -19,7 +19,7 @@
         combat climate change.
       </p>
 
-      <ul>
+      <ul class="bulleted">
         <li>
           <a href="https://call4climate.com/">Call4Climate (USA)</a> -
           Call4Climate is a hotline that connects you to your representatives in
@@ -30,7 +30,7 @@
 
       <h2>Individual Actions</h2>
 
-      <ul>
+      <ul class="bulleted">
         <li>
           <strong>Electrify Your Appliances</strong> - you might have home
           appliances like a stove, water heater, or dryer that burn fossil fuels

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -41,9 +41,9 @@ sub {
   font-size: smaller;
 }
 
-ul {
+ul.-bulleted {
   list-style: disc;
-  margin-left: $standard;
+  margin-left: $large;
   margin-top: $standard;
 
   li { margin-top: $small; }

--- a/styles/overlay.scss
+++ b/styles/overlay.scss
@@ -29,9 +29,9 @@
   padding: $large;
   color: $text-grey;
 
-  // Large overlays are 800px wide
+  // Large overlays are 1000px wide
   &.-large {
-    flex-basis: 50rem;
+    flex-basis: 62.5rem;
   }
 
   .title {

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,6 +907,216 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-array@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.0.1.tgz#0ff28ee7052a2e504cb951d17df7437c33d442d6"
+  integrity sha512-D/G7oG0czeszALrkdUiV68CDiHDxXf+M2mLVqAyKktGd12VKQQljj1sHJGBKjcK4jRH1biBd6ZPQPHpJ0mNa0w==
+
+"@types/d3-axis@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-axis/-/d3-axis-3.0.1.tgz#6afc20744fa5cc0cbc3e2bd367b140a79ed3e7a8"
+  integrity sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-brush/-/d3-brush-3.0.1.tgz#ae5f17ce391935ca88b29000e60ee20452c6357c"
+  integrity sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-chord/-/d3-chord-3.0.1.tgz#54c8856c19c8e4ab36a53f73ba737de4768ad248"
+  integrity sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==
+
+"@types/d3-color@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.0.2.tgz#53f2d6325f66ee79afd707c05ac849e8ae0edbb0"
+  integrity sha512-WVx6zBiz4sWlboCy7TCgjeyHpNjMsoF36yaagny1uXfbadc9f+5BeBf7U+lRmQqY3EHbGQpP8UdW8AC+cywSwQ==
+
+"@types/d3-contour@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-contour/-/d3-contour-3.0.1.tgz#9ff4e2fd2a3910de9c5097270a7da8a6ef240017"
+  integrity sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-delaunay/-/d3-delaunay-6.0.0.tgz#c09953ac7e5460997f693d2d7bf3522e0d4a88e6"
+  integrity sha512-iGm7ZaGLq11RK3e69VeMM6Oqj2SjKUB9Qhcyd1zIcqn2uE8w9GFB445yCY46NOQO3ByaNyktX1DK+Etz7ZaX+w==
+
+"@types/d3-dispatch@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz#a1b18ae5fa055a6734cb3bd3cbc6260ef19676e3"
+  integrity sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==
+
+"@types/d3-drag@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-drag/-/d3-drag-3.0.1.tgz#fb1e3d5cceeee4d913caa59dedf55c94cb66e80f"
+  integrity sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-3.0.0.tgz#f3c61fb117bd493ec0e814856feb804a14cfc311"
+  integrity sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==
+
+"@types/d3-ease@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.0.tgz#c29926f8b596f9dadaeca062a32a45365681eae0"
+  integrity sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==
+
+"@types/d3-fetch@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-fetch/-/d3-fetch-3.0.1.tgz#f9fa88b81aa2eea5814f11aec82ecfddbd0b8fe0"
+  integrity sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-force/-/d3-force-3.0.3.tgz#76cb20d04ae798afede1ea6e41750763ff5a9c82"
+  integrity sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==
+
+"@types/d3-format@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-3.0.1.tgz#194f1317a499edd7e58766f96735bdc0216bb89d"
+  integrity sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==
+
+"@types/d3-geo@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-geo/-/d3-geo-3.0.2.tgz#e7ec5f484c159b2c404c42d260e6d99d99f45d9a"
+  integrity sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-hierarchy/-/d3-hierarchy-3.0.2.tgz#ca63f2f4da15b8f129c5b7dffd71d904cba6aca2"
+  integrity sha512-+krnrWOZ+aQB6v+E+jEkmkAx9HvsNAD+1LCD0vlBY3t+HwjKnsBFbpVLx6WWzDzCIuiTWdAxXMEnGnVXpB09qQ==
+
+"@types/d3-interpolate@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz#e7d17fa4a5830ad56fe22ce3b4fac8541a9572dc"
+  integrity sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.0.0.tgz#939e3a784ae4f80b1fde8098b91af1776ff1312b"
+  integrity sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==
+
+"@types/d3-polygon@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-polygon/-/d3-polygon-3.0.0.tgz#5200a3fa793d7736fa104285fa19b0dbc2424b93"
+  integrity sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==
+
+"@types/d3-quadtree@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz#433112a178eb7df123aab2ce11c67f51cafe8ff5"
+  integrity sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==
+
+"@types/d3-random@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-3.0.1.tgz#5c8d42b36cd4c80b92e5626a252f994ca6bfc953"
+  integrity sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==
+
+"@types/d3-scale-chromatic@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#103124777e8cdec85b20b51fd3397c682ee1e954"
+  integrity sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==
+
+"@types/d3-scale@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.1.tgz#fbe8238e2eff27af577d2b7d0b933ae50a546970"
+  integrity sha512-GDuXcRcR6mKcpUVMhPNttpOzHi2dP6YcDqLZYSZHgwTZ+sfCa8e9q0VEBwZomblAPNMYpVqxojnSyIEb4s/Pwg==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-selection/-/d3-selection-3.0.1.tgz#e57b01ab69b18b380f68db97b76ceefe62f17191"
+  integrity sha512-aJ1d1SCUtERHH65bB8NNoLpUOI3z8kVcfg2BGm4rMMUwuZF4x6qnIEKjT60Vt0o7gP/a/xkRVs4D9CpDifbyRA==
+
+"@types/d3-shape@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.0.2.tgz#4b1ca4ddaac294e76b712429726d40365cd1e8ca"
+  integrity sha512-5+ButCmIfNX8id5seZ7jKj3igdcxx+S9IDBiT35fQGTLZUfkFgTv+oBH34xgeoWDKpWcMITSzBILWQtBoN5Piw==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time-format@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time-format/-/d3-time-format-4.0.0.tgz#ee7b6e798f8deb2d9640675f8811d0253aaa1946"
+  integrity sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==
+
+"@types/d3-time@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.0.tgz#e1ac0f3e9e195135361fa1a1d62f795d87e6e819"
+  integrity sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==
+
+"@types/d3-timer@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.0.tgz#e2505f1c21ec08bda8915238e397fb71d2fc54ce"
+  integrity sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==
+
+"@types/d3-transition@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-transition/-/d3-transition-3.0.1.tgz#c9a96125567173d6163a6985b874f79154f4cc3d"
+  integrity sha512-Sv4qEI9uq3bnZwlOANvYK853zvpdKEm1yz9rcc8ZTsxvRklcs9Fx4YFuGA3gXoQN/c/1T6QkVNjhaRO/cWj94g==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-3.0.1.tgz#4bfc7e29625c4f79df38e2c36de52ec3e9faf826"
+  integrity sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3/-/d3-7.0.0.tgz#d102ec6ea5741e51a1ff7b8228850db0665ccd27"
+  integrity sha512-7rMMuS5unvbvFCJXAkQXIxWTo2OUlmVXN5q7sfQFesuVICY55PSP6hhbUhWjTTNpfTTB3iLALsIYDFe7KUNABw==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -927,6 +1137,11 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/geojson@*":
+  version "7946.0.8"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.8.tgz#30744afdb385e2945e22f3b033f897f76b1f12ca"
+  integrity sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==
 
 "@types/glob@^7.1.1":
   version "7.1.3"
@@ -2547,6 +2762,11 @@ commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@^2.12.1, commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -2936,6 +3156,250 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
 
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.0.2.tgz#7a65593784cfc0150eee1aba8d3e69a6fe73be7b"
+  integrity sha512-nTN4OC6ufZueotlexbxBd2z8xmG1eIfhvP2m1auH2ONps0L+AZn1r0JWuzMXZ6XgOj1VBOp7GGZmEs9NUFEBbA==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.0.1.tgz#03316e595955d1fcd39d9f3610ad41bb90194d0a"
+  integrity sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw==
+
+d3-contour@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-3.0.1.tgz#2c64255d43059599cd0dba8fe4cc3d51ccdd9bbd"
+  integrity sha512-0Oc4D0KyhwhM7ZL0RMnfGycLN7hxHB8CMmwZ3+H26PWAG0ozNuYG5hXSDNgmP1SgJkQMrlG6cP20HoaSbvcJTQ==
+  dependencies:
+    d3-array "2 - 3"
+
+d3-delaunay@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.2.tgz#7fd3717ad0eade2fc9939f4260acfb503f984e92"
+  integrity sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.0.1.tgz#e41b81b2ab79277141ec1404aa5d05001da64084"
+  integrity sha512-hdL7+HBIohpgfolhBxr1KX47VMD6+vVD/oEFrxk5yhmzV2prk99EkFKYpXuhVkFpTgHdJ6/4bYcjdLPPXV4tIA==
+
+d3-geo@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.0.1.tgz#4f92362fd8685d93e3b1fae0fd97dc8980b1ed7e"
+  integrity sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.0.1.tgz#0365342d54972e38ca05e9143e0ab1c60846b3b5"
+  integrity sha512-RlLTaofEoOrMK1JoXYIGhKTkJFI/6rFrYPgxy6QlZo2BcVc4HGTqEU0rPpzuMq5T/5XcMtAzv1XiLA3zRTfygw==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+"d3-path@1 - 3", d3-path@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.0.1.tgz#f09dec0aaffd770b7995f1a399152bf93052321e"
+  integrity sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-scale-chromatic@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.0.tgz#294377ea1d7e5a31509ee648b98d7916ac0b34e3"
+  integrity sha512-foHQYKpWQcyndH1CGoHdUC4PECxTxonzwwBXGT8qu+Drb1FIc6ON6dG2P5f4hRRMkLiIKeWK7iFtdznDUrnuPQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.0.1.tgz#9ccdfb28fd9b0d12f2d8aec234cd5c4a9ea27931"
+  integrity sha512-HNZNEQoDhuCrDWEc/BMbF/hKtzMZVoe64TvisFLDp2Iyj0UShB/E6/lBsLlJTfBMbYgftHj90cXJ0SEitlE6Xw==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.0.0.tgz#930ded86a9de761702344760d8a25753467f28b7"
+  integrity sha512-nzaCwlj+ZVBIlFuVOT1RmU+6xb/7D5IcnhHzHQcBgS/aTa5K9fWZNN5LCXA27LgF5WxoSNJqKBbLcGMtM6Ca6A==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.0.0.tgz#65972cb98ae2d4954ef5c932e8704061335d4975"
+  integrity sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.0.1.tgz#ecd7eb094c398ec71dd61e8628a97ddf1c404d20"
+  integrity sha512-74zonD4nAtxF9dtwFwJ3RuoHPh2D/UTFX26midBuMVH+7pRbOezuyLUIb8mbQMuYFlcUXT+xy++orCmnvMM/CA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "3"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -3066,6 +3530,13 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+delaunator@5:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.0.tgz#60f052b28bd91c9b4566850ebf7756efe821d81b"
+  integrity sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==
+  dependencies:
+    robust-predicates "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -4409,6 +4880,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -4535,6 +5013,11 @@ internal-ip@^4.3.0:
   dependencies:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
+
+"internmap@1 - 2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.1.tgz#33d0fa016185397549fb1a14ea3dbe5a2949d1cd"
+  integrity sha512-Ujwccrj9FkGqjbY3iVoxD1VV+KdZZeENx0rphrtzmRXbFvkFO88L80BL/zeSIguX/7T+y8k04xqtgWgS5vxwxw==
 
 interpret@^1.2.0:
   version "1.4.0"
@@ -6868,6 +7351,11 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+robust-predicates@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.1.tgz#ecde075044f7f30118682bd9fb3f123109577f9a"
+  integrity sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -6883,6 +7371,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs@^6.6.0:
   version "6.6.6"
@@ -6904,7 +7397,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 


### PR DESCRIPTION
Mainly added a new graph to the Analytics overlay that shows you yearly emissions by the associated tile type. Here's a demo where a lot of emission reduction policies have been put in place:

![Screenshot from 2021-09-05 23-06-37](https://user-images.githubusercontent.com/3187531/132155334-27ecdf57-7e26-4030-88ef-c80bf5544925.png)

Also added several new tile options and related policies to increase the potential the total option weight from 89.5% to 97.9%, so you can almost completely zero out possible emissions. In response to feedback, I also added a text label to the thermometer and faded out non-interactive tiles:

![Screenshot from 2021-09-05 23-06-46](https://user-images.githubusercontent.com/3187531/132155312-f3576703-b28f-4cd8-a52c-3c2bcb9c4cf3.png)