### PR TITLE
More Misc. Fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,7 +42,8 @@
             <img src="@/assets/earth.svg" alt=""
               width="20" height="20">
           </label>
-          <select v-model="$i18n.locale" id="lang-select">
+          <select v-model="$i18n.locale" id="lang-select"
+            @change="langagugeChanged">
             <option v-for="langObj in AvailableLanguages"
               :key="`${langObj.locale}`"
               :value="langObj.locale">
@@ -64,6 +65,7 @@
 <script lang="ts">
 import { Options, Vue } from 'vue-class-component';
 
+import { i18n } from '@/i18n-init';
 import router from '@/router'
 import { AvailableLanguages } from '@/constants/languages';
 
@@ -86,10 +88,27 @@ import { AvailableLanguages } from '@/constants/languages';
      */
     handleScroll() {
       this.isScrolledDown = window.pageYOffset > 10;
-    }
+    },
+
+    /**
+     * Called when the user changes languages - we re-set the document title
+     * from the current route and store the route in localStorage to ensure it
+     * persists over multiple sessions
+     */
+    langagugeChanged() {
+      App.setTitleFromRoute(this.$route);
+
+      localStorage.setItem(App.LocaleStorageKey, this.$i18n.locale);
+    },
   },
 
   mounted() {
+    const cachedLocale = localStorage.getItem(App.LocaleStorageKey);
+
+    if (cachedLocale) {
+      this.$i18n.locale = cachedLocale;
+    }
+
     const closeMenuFunc = this.closeMenu;
 
     // Watch for route changes and close the mobile menu
@@ -103,7 +122,22 @@ import { AvailableLanguages } from '@/constants/languages';
   }
 })
 
-export default class App extends Vue { }
+export default class App extends Vue {
+  static readonly LocaleStorageKey = 'i18n-locale';
+
+  /**
+   * Set the document title based on the current route using the i18n library to
+   * ensure it's translated to the user's desired language
+   */
+  static setTitleFromRoute(route: any) {
+    // Run the app and page title through translation before updating title
+    const appTitle = i18n.global.t('title');
+    const pageTitle = i18n.global.t(String(route.meta.titlei18nKey));
+
+    document.title = `${pageTitle} | ${appTitle}`;
+  }
+
+}
 </script>
 
 <style lang="scss">

--- a/src/classes/simulator.ts
+++ b/src/classes/simulator.ts
@@ -142,10 +142,10 @@ export class Simulator {
 
   /**
    * Get the number of years left in the simulation time till our end year
-   * (2100). E.g. in 2025 this would return 75.
+   * (2100). E.g. in 2025 this would return 76 (since we also simulate 2100).
    */
   public static getTotalSimulationYears(): number {
-    return SimEndYear - Simulator.getCurrentYear();
+    return SimEndYear - Simulator.getCurrentYear() + 1;
   }
 
   /**
@@ -184,7 +184,7 @@ export class Simulator {
   /**
    * Given a tile option, returns the difference in total emissions (over the
    * remaining simulator years) this tile's state creates, in Gigatonnes CO2.
-   * For example setting a tile to increase the share of electirc cars would
+   * For example setting a tile to increase the share of electric cars would
    * return a negative  number.
    */
   public static getOptionTotalEmissionDelta(
@@ -201,7 +201,7 @@ export class Simulator {
   /**
    * Given a tile option, returns the difference in total emissions (over the
    * remaining simulator years) this tile's state creates, in Gigatonnes CO2.
-   * For example setting a tile to increase the share of electirc cars would
+   * For example setting a tile to increase the share of electric cars would
    * return a negative  number.
    *
    * TODO: Write unit tests for this function
@@ -227,7 +227,7 @@ export class Simulator {
 
     // Loop through every year of the simulation and calculate emissions in in
     // that year
-    for (let i = 0; i <= totalSimYears; i++) {
+    for (let i = 0; i < totalSimYears; i++) {
       const currYear = startYear + i;
 
       // If the current year is beyond the option's target year, we've reached
@@ -295,6 +295,8 @@ export class Simulator {
    *
    * This is necessary since some emissions sources cannot be changed within
    * our simulator and to make the system more reliable.
+   *
+   * TODO: Add unit tests for this
    */
   public static getTotalEmissionsData(currentTiles: Array<TileObj>): ITotalEmissionsWithBreakdown {
     let totalTileDelta = 0;

--- a/src/components/SimulatorBoard.vue
+++ b/src/components/SimulatorBoard.vue
@@ -41,11 +41,13 @@
 
       <div class="boards-cont">
         <div class="simulator-board -main">
+          <!-- Disabled tiles that aren't the selected one when is selected to
+            prevent switching tiles too quickly and breaking the sidebar -->
           <Tile v-for="(tile, index) in tiles"
             v-bind:key="tile.id"
             :tile="tile"
             :tileNum="index"
-            :disabled="selectedTile"
+            :disabled="selectedTile && tile.id !== selectedTile.id"
             :class="{ '-active': tile.id === selectedTile?.id }"
             @selected="selectTile(tile)" />
         </div>

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -2,7 +2,6 @@
   <!-- Show tile as a <div> if it's scenery, <button> if interactive -->
   <button v-if="!tile.isScenery()"
     class="tile"
-    :disabled="disabled"
     :style="{ 'animation-delay': animDelay }"
     @click="tileSelected()">
     <div class="above-ground -building">
@@ -46,6 +45,8 @@ const GridAnimDelaySec = AnimationOffsetSec * Math.pow(GridWidth, 2);
   props: {
     tile: {} as TileObj,
     tileNum: 0,
+
+    /** Whether this tile is disabled and should do nothing on click */
     disabled: false,
   },
 
@@ -60,6 +61,10 @@ const GridAnimDelaySec = AnimationOffsetSec * Math.pow(GridWidth, 2);
 
   methods: {
     tileSelected(): void {
+      if (this.disabled) {
+        return;
+      }
+
       this.$emit('selected', this.tile);
     }
   },

--- a/src/interfaces/language-data.ts
+++ b/src/interfaces/language-data.ts
@@ -72,5 +72,12 @@ export interface ILanguageData {
         description: string;
       };
     }
+  },
+
+  notFound: {
+    title: string;
+    heading: string;
+    body: string;
+    returnText: string;
   }
 }

--- a/src/locales/english.ts
+++ b/src/locales/english.ts
@@ -240,5 +240,12 @@ export const EnglishLanguageData: ILanguageData = {
         description: 'Use tax incentives and subsidies to cut emissions from home heating and other unallocated sources in half by 2050.',
       },
     }
+  },
+
+  notFound: {
+    title: 'Not Found',
+    heading: '404 - Page Not Found!',
+    body: "Hm, we couldn't find that page!",
+    returnText: 'Return to Carbon Challenge Home',
   }
 };

--- a/src/locales/spanish.ts
+++ b/src/locales/spanish.ts
@@ -236,5 +236,12 @@ export const SpanishLanguageData: ILanguageData = {
         description: '',
       },
     }
-  }
+  },
+
+  notFound: {
+     title: 'No encontrado',
+     heading: '404 - ¡Página no encontrada!',
+     body: "Hm, ¡no pudimos encontrar esa página!",
+     returnText: 'Regresar al inicio del Carbon Challenge',
+   },
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -53,7 +53,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/:pathMatch(.*)*',
     component: NotFound,
     meta: {
-      titlei18nKey: 'header.takeAction'
+      titlei18nKey: 'notFound.title'
     }
   }
 ]

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,5 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 
-import { i18n } from '@/i18n-init';
-
 import App from '@/App.vue'
 
 // Static pages (views)
@@ -65,11 +63,7 @@ const router = createRouter({
 
 // This callback runs before every route change, including on page load.
 router.beforeEach(function(to, from, next) {
-  // Run the app and page title through translation before updating title
-  const appTitle = i18n.global.t('title');
-  const pageTitle = i18n.global.t(String(to.meta.titlei18nKey));
-
-  document.title = `${pageTitle} | ${appTitle}`
+  App.setTitleFromRoute(to);
 
   // Reset scroll position
   window.scrollTo(0, 0);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import App from '@/App.vue'
 // Static pages (views)
 import About from '@/views/About.vue'
 import FAQ from '@/views/FAQ.vue'
+import NotFound from '@/views/NotFound.vue';
 import TakeAction from '@/views/TakeAction.vue'
 // Actual components
 import Intro from '@/components/Intro.vue'
@@ -15,7 +16,6 @@ import SimulatorBoard from '@/components/SimulatorBoard.vue'
 const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
-    name: 'Home',
     component: Intro,
     meta: {
       titlei18nKey: 'header.home'
@@ -23,7 +23,6 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: '/simulator',
-    name: 'SimulatorBoard',
     component: SimulatorBoard,
     meta: {
       titlei18nKey: 'header.simulator'
@@ -31,7 +30,6 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: '/about',
-    name: 'About',
     component: About,
     meta: {
       titlei18nKey: 'header.about'
@@ -39,7 +37,6 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: '/faq',
-    name: 'FAQ',
     component: FAQ,
     meta: {
       titlei18nKey: 'header.faq'
@@ -47,8 +44,14 @@ const routes: Array<RouteRecordRaw> = [
   },
   {
     path: '/take-action',
-    name: 'Take Action',
     component: TakeAction,
+    meta: {
+      titlei18nKey: 'header.takeAction'
+    }
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    component: NotFound,
     meta: {
       titlei18nKey: 'header.takeAction'
     }

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -68,8 +68,7 @@
         However, if you see something really wrong in our calculations, please
         help the Carbon Challenge improve by filing an issue on the
         <a href="https://github.com/vkoves/carbon-challenge">
-          Carbon Challenge GitHub
-        </a>!
+          Carbon Challenge GitHub</a>!
       </p>
 
       <h2>References</h2>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,14 +1,16 @@
 <template>
   <main id="main-content" class="page">
     <div class="page-inner">
-      <h1>404 - Page Not Found!</h1>
+      <h1>{{ $t('notFound.heading') }}</h1>
 
       <p>
-        Hm, we couldn't find that page!
+        {{ $t('notFound.body') }}
       </p>
 
       <p>
-        <a href="/">Return to Carbon Challenge Home</a>
+        <a href="/">
+          {{ $t('notFound.returnText') }}
+        </a>
       </p>
     </div>
   </main>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,15 @@
+<template>
+  <main id="main-content" class="page">
+    <div class="page-inner">
+      <h1>404 - Page Not Found!</h1>
+
+      <p>
+        Hm, we couldn't find that page!
+      </p>
+
+      <p>
+        <a href="/">Return to Carbon Challenge Home</a>
+      </p>
+    </div>
+  </main>
+</template>

--- a/tests/unit/simulator.spec.ts
+++ b/tests/unit/simulator.spec.ts
@@ -1,5 +1,11 @@
-import { expect } from 'chai'
-import { Simulator, GridWidth } from '@/classes/simulator';
+import { expect, should } from 'chai';
+import chai from 'chai';
+
+import {
+  GridWidth,
+  OrigYearlyEmissionsGigaTonnes,
+  Simulator,
+} from '@/classes/simulator';
 
 describe('Simulator', () => {
   describe('generateTiles', () => {
@@ -8,5 +14,69 @@ describe('Simulator', () => {
 
       expect(tiles.length).equal(GridWidth * GridWidth)
     })
+  });
+
+  describe('getPolicyEmissionsDelta', () => {
+    const TotalSimYears = 5;
+    const CurrentYear = Simulator.getCurrentYear();
+    const TestWeightDec = 0.5;
+
+    it('should return total delta equal to simYears * weight * OrigEmissions if past targetYear and target is 100%', () => {
+      const TotalSimYears = Simulator.getTotalSimulationYears();
+
+      const simDeltas = Simulator.getPolicyEmissionsDelta({
+        current: 0,
+        target: 100,
+        targetYear: CurrentYear,
+        weightPrcnt: TestWeightDec * 100,
+      });
+
+      const expectedEmissionsReduction
+        = Math.round(-OrigYearlyEmissionsGigaTonnes * TestWeightDec * TotalSimYears);
+
+      expect(Math.round(simDeltas.total)).equal(expectedEmissionsReduction);
+    });
+
+    it('should return total delta equal to 1/2 * simYears * weight * OrigEmissions if past targetYear and target is 50%', () => {
+      const TotalSimYears = Simulator.getTotalSimulationYears();
+
+      const TargetDec = 0.5;
+
+      const simDeltas = Simulator.getPolicyEmissionsDelta({
+        current: 0,
+        target: TargetDec * 100,
+        targetYear: CurrentYear,
+        weightPrcnt: TestWeightDec * 100,
+      });
+
+      const expectedEmissionsReduction
+        = Math.round(-OrigYearlyEmissionsGigaTonnes * TestWeightDec * TotalSimYears * TargetDec);
+
+      expect(Math.round(simDeltas.total)).equal(expectedEmissionsReduction);
+    });
+
+    // TODO: Add unit test confirming future targetYear works properly
+  });
+
+  describe('getTotalEmissionsData', () => {
+    // TODO: Add tests
+  });
+
+  describe('validateNumInRange', () => {
+    it('throws an error if value is greater than max', () => {
+      expect(() => Simulator.validateNumInRange('test', 112, 0, 100)).to.throw(Error);
+    });
+
+    it('throws an error if value is less than min', () => {
+      expect(() => Simulator.validateNumInRange('test', -5, 0, 100)).to.throw(Error);
+    });
+
+    it('does not throw an error if value is in range', () => {
+      expect(() => Simulator.validateNumInRange('test', 10, 0, 100)).not.to.throw(Error);
+    });
+
+    it('does not throw an error if value is on edge of range', () => {
+      expect(() => Simulator.validateNumInRange('test', 0, 0, 100)).not.to.throw(Error);
+    });
   });
 })


### PR DESCRIPTION
Made some more miscellaneous fixes, in particular:

- Added a not found (404 page) that shows on bad routes (like `/nonsense`) 
- Fixed TileOverlay not restoring focus to the selected tile
- Fixed extra whitespace before ! on about page
- Wrote a few extra unit tests for the `Simulator` to verify the basics of the emission calculation
- Language selection is now cached in `localStorage` and instantly updates the page title