### PR TITLE
Add Reforestation & Carbon Sink Support

### DIFF
--- a/src/classes/tile-obj.ts
+++ b/src/classes/tile-obj.ts
@@ -26,7 +26,7 @@ export class TileObj {
    */
   isScenery(): boolean {
     return this.type === TileType.Empty
-      || this.type === TileType.Forest
+      || this.type === TileType.ForestD
       || this.type === TileType.Lake;
   }
 

--- a/src/components/AnalyticsOverlay.vue
+++ b/src/components/AnalyticsOverlay.vue
@@ -81,6 +81,12 @@
                     <strong>Agriculture:</strong>
                     {{ tooltipData.datum.farm.toFixed(2) }} GT
                   </li>
+
+                  <li>
+                    <div class="legend-square -forest"></div>
+                    <strong>Forests:</strong>
+                    {{ tooltipData.datum.forest.toFixed(2) }} GT
+                  </li>
                 </ul>
               </template>
             </div>
@@ -228,7 +234,9 @@ export default class AnalyticsOverlay extends Vue {
     this.tiles.forEach(tile => {
       Object.values(tile.options)
         .forEach((option: IOption) => {
-          totalWeight += option.weightPrcnt;
+          if (option.weightPrcnt) {
+            totalWeight += option.weightPrcnt;
+          }
         });
     });
 
@@ -270,7 +278,7 @@ export default class AnalyticsOverlay extends Vue {
         .style('text-anchor', 'end');
 
     // TODO: Move this into a constant
-    const emissionGroups = [ 'factory', 'farm', 'home', 'office', 'power' ];
+    const emissionGroups = [ 'factory', 'farm', 'forest', 'home', 'office', 'power' ];
 
     // Add Y axis
     this.yScale = d3.scaleLinear()
@@ -303,7 +311,9 @@ export default class AnalyticsOverlay extends Vue {
             return this.yScale(d[1]);
           })
           .attr('height', (d: IStackedDatum) => {
-            return this.yScale(d[0]) - this.yScale(d[1]);
+            // Prevent negative heights from carbon sinks and just make them 0
+            // height on the graph
+            return Math.max(this.yScale(d[0]) - this.yScale(d[1]), 0);
           })
           .attr('width', this.xScale.bandwidth())
           .on('click', (event: PointerEvent, d: IStackedDatum) => {
@@ -373,6 +383,7 @@ $powerColor:    #ffc200;
 $officeColor:   #5c76ff;
 $factoryColor:  #bd8d6b;
 $farmColor:     #5cb860;
+$forestColor:   #397a3c;
 
 .graph-cont {
   overflow: auto;
@@ -392,6 +403,7 @@ figure {
       &.-home rect { fill: $homeColor; }
       &.-office rect { fill: $officeColor; }
       &.-power rect { fill: $powerColor; }
+      &.-forest rect { fill: $forestColor; }
     }
 
     .bar {
@@ -416,6 +428,7 @@ figure {
 
     &.-factory { background: $factoryColor; }
     &.-farm { background: $farmColor; }
+    &.-forest { background: $forestColor; }
     &.-home { background: $homeColor; }
     &.-office { background: $officeColor; }
     &.-power { background: $powerColor; }
@@ -425,7 +438,7 @@ figure {
     visibility: hidden;
     position: absolute;
     padding: $standard;
-    bottom: 50px;
+    bottom: 0.5rem;
     min-width: 19rem;
     border-radius: 0.25rem;
     background-color: $white;
@@ -444,7 +457,7 @@ figure {
       border-bottom: $tipWidth solid transparent;
       border-right-color: rgb(255 255 255);
       left: -$tipWidth;
-      bottom: 1.5rem;
+      bottom: 5rem;
       content: "";
     }
 

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -171,7 +171,7 @@ export default class Tile extends Vue { }
       margin-left: 10%;
     }
 
-    &.forest {
+    &.forest, &.forest-decor {
       background-position: 100% 5%;
     }
 

--- a/src/constants/tile-policies.ts
+++ b/src/constants/tile-policies.ts
@@ -25,7 +25,6 @@ export enum TilePolicyKey {
 
   // Farm tile policies
   FarmManureManagement2050 = 'FarmManureManagement',
-  FarmDeforestationElimination2050 = 'FarmDeforestationElimination2050',
   FarmRenewableEnergyRequirement2050 = 'FarmRenewableEnergyRequirement2050',
   FarmRenewableEnergyMagic = 'FarmRenewableEnergyMagic',
   FarmAgriculturalSoilReducedFertilizer = 'FarmAgriculturalSoilReducedFertilizer',
@@ -33,6 +32,12 @@ export enum TilePolicyKey {
   FarmCroplandManagement = 'FarmCroplandManagement',
   FarmCropBurningReduction = 'FarmCropBurningReduction',
   FarmCropBurningBan = 'FarmCropBurningBan',
+
+  // Forest tile policies
+  ForestDeforestationReduction2050 = 'ForestDeforestationReduction2050',
+  ForestDeforestationElimination2050 = 'ForestDeforestationElimination2050',
+  ForestSomeReforestation2050 = 'ForestSomeReforestation2050',
+  ForestMaxReforestation2050 = 'ForestMaxReforestation2050',
 
   // Home tile policies
   HomeElectricVehicleRequirement2050 = 'HomeElectricVehicleRequirement2050',
@@ -138,13 +143,6 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       targetYear: 2050,
     },
   ],
-  [TileOption.Deforestation]: [
-    {
-      key: TilePolicyKey.FarmDeforestationElimination2050,
-      target: 100,
-      targetYear: 2050,
-    },
-  ],
   [TileOption.EnergyAgriculture]: [
     {
       key: TilePolicyKey.FarmRenewableEnergyRequirement2050,
@@ -188,6 +186,32 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
       target: 100,
       targetYear: 2050,
     }
+  ],
+
+  // Forest options
+  [TileOption.Reforestation]: [
+    {
+      key: TilePolicyKey.ForestSomeReforestation2050,
+      target: 50,
+      targetYear: 2050,
+    },
+    {
+      key: TilePolicyKey.ForestMaxReforestation2050,
+      target: 100,
+      targetYear: 2050,
+    },
+  ],
+  [TileOption.Deforestation]: [
+    {
+      key: TilePolicyKey.ForestDeforestationReduction2050,
+      target: 50,
+      targetYear: 2050,
+    },
+    {
+      key: TilePolicyKey.ForestDeforestationElimination2050,
+      target: 100,
+      targetYear: 2050,
+    },
   ],
 
   // Home options

--- a/src/constants/tile-policies.ts
+++ b/src/constants/tile-policies.ts
@@ -308,7 +308,7 @@ export const TilePolicies: { [opt in TileOption]: Array<IOptionPolicy> } = {
   [TileOption.UnallocatedFuelCombustion]: [
     {
       key: TilePolicyKey.PowerUnallocatedFuelReduction2050,
-      target: 50,
+      target: 80,
       targetYear: 2050,
     },
   ],

--- a/src/interfaces/tile-interfaces.ts
+++ b/src/interfaces/tile-interfaces.ts
@@ -11,11 +11,12 @@ import { TilePolicyKey } from '../constants/tile-policies';
 export enum TileType {
   // Scenery (non-interactive) tile types
   Empty = 'empty',
-  Forest = 'forest',
+  ForestD = 'forest-decor',
   Lake = 'lake',
   // Actual interactive types
   Factory = 'factory',
   Farm = 'farm',
+  Forest = 'forest',
   Home = 'home',
   Office = 'office',
   Power = 'power',
@@ -50,6 +51,7 @@ export enum TileOption {
   FugitiveEmissions = 'fugitiveEmissions',
   LivestockAndManure = 'livestockAndManure',
   PassengerRoadTransport = 'passengerRoadTransport',
+  Reforestation = 'reforestation',
   Shipping = 'shipping',
   UnallocatedFuelCombustion = 'unallocatedFuelCombustion',
   Waste = 'waste',
@@ -57,13 +59,15 @@ export enum TileOption {
 
 /**
  * The bare-bones of an emissions policy with a weight that we can run
- * calculations on. The tile options implement this.
+ * calculations on. The tile options interface (IOption) implements this, see
+ * that for documentation.
  */
 export interface IWeightedPolicy {
   current: number;
   target: number;
   targetYear: number;
-  weightPrcnt: number;
+  weightPrcnt?: number;
+  maxCO2Sequestered?: number;
 }
 
 /**
@@ -166,12 +170,20 @@ export interface IOption extends IWeightedPolicy {
 
   /**
    * A percentage number expressing the weight of this option as a % of current
-   * global emissions.
+   * global emissions. This could be undefined if this options is a carbon sink that
+   * we can scale up, rather than an emission source we scale down.
    *
    * Example: In 2016, residential building energy use in 2016 was 10.9% of
-   * emissions so this value would be 10.9
+   * emissions so this value would be 10.9.
    */
-  weightPrcnt: number;
+  weightPrcnt?: number;
+
+  /**
+   * The maximum Gigatonnes per year that can be sequestered with this carbon
+   * sequestration policy. This is undefined on most options (since they are carbon
+   * sources) and is only set on carbon sinks like reforestation.
+   */
+  maxCO2Sequestered?: number;
 
   /**
    * An array of potential changes that can be made to this option. These are

--- a/src/locales/english.ts
+++ b/src/locales/english.ts
@@ -47,7 +47,7 @@ export const EnglishLanguageData: ILanguageData = {
     tileTypes: {
       power: 'Power Plant',
       farm: 'Farm',
-      forest: 'Forest',
+      forest: 'Forests',
       home: 'Home',
       office: 'Office',
       factory: 'Factory',
@@ -61,7 +61,7 @@ export const EnglishLanguageData: ILanguageData = {
       power:
         'Emissions that are broadly tied to generating power. Emissions for ' +
         'specific uses are under the Home, Office, and Factory tiles.',
-      farm: '',
+      farm: 'Emissions related to agriculture, including livestock',
       forest: '',
       home: 'Emissions related to homes and individual behaviors like driving.',
       office: '',
@@ -253,7 +253,7 @@ export const EnglishLanguageData: ILanguageData = {
       },
       [TilePolicyKey.PowerUnallocatedFuelReduction2050]: {
         name: 'Reduce Unallocated Fuel Emissions',
-        description: 'Use tax incentives and subsidies to cut emissions from home heating and other unallocated sources in half by 2050.',
+        description: 'Use strict laws to reduce emissions from home heating and other unallocated sources 80% by 2050.',
       },
     }
   },

--- a/src/locales/english.ts
+++ b/src/locales/english.ts
@@ -74,6 +74,7 @@ export const EnglishLanguageData: ILanguageData = {
     tileOptionTitles: {
       [TileOption.Aviation]: 'Aviation',
       [TileOption.Deforestation]: 'Deforestation',
+      [TileOption.Reforestation]: 'Reforestation',
       [TileOption.EnergyAgriculture]: 'Energy for Agriculture',
       [TileOption.EnergyCommercialBuildings]: 'Energy for Commercial Buildings',
       [TileOption.EnergyIndustry]: 'Energy for Industry',
@@ -142,10 +143,6 @@ export const EnglishLanguageData: ILanguageData = {
         name: 'Manure Management',
         description: 'Require better manure management to halve emissions from livestock and manure by 2050.',
       },
-      [TilePolicyKey.FarmDeforestationElimination2050]: {
-        name: 'Eliminate Deforestation by 2050',
-        description: 'Fully eliminate deforestation by 2050.',
-      },
       [TilePolicyKey.FarmRenewableEnergyRequirement2050]: {
         name: 'Require Green Energy for Farming by 2050',
         description: 'Require farming to run on fully renewable energy by 2050.',
@@ -173,6 +170,24 @@ export const EnglishLanguageData: ILanguageData = {
       [TilePolicyKey.FarmCropBurningBan]: {
         name: 'Ban on Crop Burning',
         description: 'Completely ban crop burning by 2050, completely eliminating those emissions.',
+      },
+
+      // Forest policies
+      [TilePolicyKey.ForestDeforestationReduction2050]: {
+        name: 'Reduce Deforestation by 2050',
+        description: 'Cut yearly deforestation in half by 2050.',
+      },
+      [TilePolicyKey.ForestDeforestationElimination2050]: {
+        name: 'Eliminate Deforestation by 2050',
+        description: 'Fully eliminate deforestation by 2050.',
+      },
+      [TilePolicyKey.ForestSomeReforestation2050]: {
+        name: 'Moderate Reforestation by 2050',
+        description: 'Reforest 4 million square kilometeres of forest.'
+      },
+      [TilePolicyKey.ForestMaxReforestation2050]: {
+        name: 'Aggressive Reforestation by 2050',
+        description: 'Reforest 9.5 million square kilometeres of forest.'
       },
 
       // Home policies

--- a/src/locales/spanish.ts
+++ b/src/locales/spanish.ts
@@ -47,7 +47,7 @@ export const SpanishLanguageData: ILanguageData = {
     tileTypes: {
       power: 'Planta de energía',
       farm: 'Granja',
-      forest: 'Bosque',
+      forest: 'Bosques',
       home: 'Casa',
       office: 'Oficina',
       factory: 'Fábrica',

--- a/src/locales/spanish.ts
+++ b/src/locales/spanish.ts
@@ -71,6 +71,7 @@ export const SpanishLanguageData: ILanguageData = {
     tileOptionTitles: {
       [TileOption.Aviation]: 'Aviación',
       [TileOption.Deforestation]: 'Deforestación',
+      [TileOption.Reforestation]: 'Reforestación',
       [TileOption.EnergyAgriculture]: 'Energía para la agricultura',
       [TileOption.EnergyCommercialBuildings]: 'Energía para edificios comerciales',
       [TileOption.EnergyIndustry]: 'Energía para la industria',
@@ -137,10 +138,6 @@ export const SpanishLanguageData: ILanguageData = {
         name: '',
         description: '',
       },
-      [TilePolicyKey.FarmDeforestationElimination2050]: {
-        name: '',
-        description: '',
-      },
       [TilePolicyKey.FarmRenewableEnergyRequirement2050]: {
         name: '',
         description: '',
@@ -170,6 +167,23 @@ export const SpanishLanguageData: ILanguageData = {
         description: '',
       },
 
+      // Forest policies
+      [TilePolicyKey.ForestDeforestationReduction2050]: {
+        name: 'Reduce Deforestation by 2050',
+        description: 'Cut yearly deforestation in half by 2050.',
+      },
+      [TilePolicyKey.ForestDeforestationElimination2050]: {
+        name: 'Eliminate Deforestation by 2050',
+        description: 'Fully eliminate deforestation by 2050.',
+      },
+      [TilePolicyKey.ForestSomeReforestation2050]: {
+        name: 'Moderate Reforestation by 2050',
+        description: 'Reforest 4 million square kilometeres of forest.'
+      },
+      [TilePolicyKey.ForestMaxReforestation2050]: {
+        name: 'Aggressive Reforestation by 2050',
+        description: 'Reforest 9.5 million square kilometeres of forest.'
+      },
 
       // Home policies
       [TilePolicyKey.HomeElectricVehicleRequirement2050]: {


### PR DESCRIPTION
Adds a new Forest tile type which now holds both deforestation and reforestation, like so:

![Screenshot from 2021-10-30 16-03-07](https://user-images.githubusercontent.com/3187531/139558339-be2db19f-0958-45ff-afc0-8f9c8965ecdc.png)

This also added the ability to add carbon sinks via a `maxCO2Sequestered` value rather than an emissions related `weightPrcnt`. Also tweaked the fugitive emissions reduction to cut those emissions 80% rather than 50%.