### PR TITLE
Add Policy Modal & Make It Show On Success

### DIFF
--- a/src/assets/checklist-white.svg
+++ b/src/assets/checklist-white.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 20 20" height="48px" viewBox="0 0 20 20" width="48px" fill="#FFFFFF"><rect fill="none" height="20" width="20"/><path d="M18,7.5h-7V6h7V7.5z M18,12.5h-7V14h7V12.5z M3.06,5.11L2,6.17L4.83,9l4.6-4.6L8.36,3.34L4.83,6.88L3.06,5.11z M3.06,11.61 L2,12.67l2.83,2.83l4.6-4.6L8.36,9.84l-3.54,3.54L3.06,11.61z"/></svg>

--- a/src/components/AnalyticsOverlay.vue
+++ b/src/components/AnalyticsOverlay.vue
@@ -14,6 +14,11 @@
 
         <h2>Total Warming Calculation</h2>
 
+        <p>
+          Curious about how these calculations were made? Check out
+          <router-link to="/about">Our About Page</router-link>.
+        </p>
+
         <dl>
           <dt>Total Emissions</dt>
           <dd>

--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -11,7 +11,7 @@
           {{ $t('intro.slogan2') }}
         </p>
 
-        <router-link to="/simulator" class="btn">
+        <router-link to="/simulator" class="btn -start">
           {{ $t('intro.startBtn') }}
         </router-link>
       </div>
@@ -78,6 +78,11 @@ export default class Intro extends Vue { }
 <style scoped lang="scss">
 @import './styles/variables/colors';
 @import './styles/variables/spacing';
+
+.btn.-start {
+  margin-top: 3rem;
+  font-size: 1.75rem;
+}
 
 .hero {
   display: flex;

--- a/src/components/PolicyOverlay.vue
+++ b/src/components/PolicyOverlay.vue
@@ -13,7 +13,7 @@
         </div>
 
         <!-- Loop through tiles and fetch their policy via -->
-        <ul>
+        <ul v-if="selectedPolicies.length > 0">
           <li v-for="(policy) in selectedPolicies" v-bind:key="policy.key" class="policy">
             <h2>
                 <img v-if="policy.isMagic"
@@ -33,6 +33,9 @@
             </p>
           </li>
         </ul>
+        <p v-else>
+          You haven't selected any policies yet!
+        </p>
       </div>
     </div>
   </focus-trap>
@@ -137,14 +140,25 @@ export default class PolicyOverlay extends Vue {
 @import './styles/variables/colors';
 @import './styles/variables/spacing';
 
-h1 { margin-bottom: $standard}
+h1 { margin-bottom: $standard; }
+
+ul {
+  max-height: 70vh;
+  overflow-y: scroll;
+  padding-right: $standard;
+  margin-top: $standard;
+  background: $light-grey;
+  padding: $standard;
+}
 
 .policy {
-  box-shadow: 0 0.1rem 0.25rem $shadow-medium;
-  border-radius: 0.25rem;
-  padding: $standard;
-  margin-top: $standard;
+  background-color: $white;
+  padding: $m-large;
   border-left: solid 0.25rem $dark-blue;
+  border-radius: 0.25rem;
+  box-shadow: 0 0.1rem 0.25rem $shadow-medium;
+
+  + .policy { margin-top: $m-large; }
 
   h2 {
     font-size: 1.25rem;

--- a/src/components/PolicyOverlay.vue
+++ b/src/components/PolicyOverlay.vue
@@ -1,0 +1,159 @@
+<template>
+  <focus-trap :returnFocusOnDeactivate="true" initialFocus="#warming-close">
+    <div class="overlay -warming" @click="closeOverlay" @keydown.esc="closeOverlay">
+      <!-- TODO: Move all text to come from i18n -->
+      <div class="overlay-content" @click="absorbClick">
+        <div class="title">
+          <h1>Your Policies</h1>
+
+          <button id="warming-close" class="btn -blue -light"
+            @click="closeOverlay">
+            Close
+          </button>
+        </div>
+
+        <!-- Loop through tiles and fetch their policy via -->
+        <ul>
+          <li v-for="(policy) in selectedPolicies" v-bind:key="policy.key" class="policy">
+            <h2>
+                <img v-if="policy.isMagic"
+                  src="@/assets/magic-wand-black.svg"
+                  class="icon -magic-wand"
+                  alt="Magic" width="24" height="24">
+
+                {{ $t(`simulator.tilePolicies.${policy.key}.name`) }}
+            </h2>
+
+            <div class="emission-change" v-if="policyEmissions[policy.key]">
+              {{ policyEmissions[policy.key] }} Gigatonnes CO<sub>2</sub>
+            </div>
+
+            <p>
+              {{ $t(`simulator.tilePolicies.${policy.key}.description`) }}
+            </p>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </focus-trap>
+</template>
+
+<script lang="ts">
+import { Options, Vue } from 'vue-class-component';
+
+import { FocusTrap } from 'focus-trap-vue';
+
+import { TilePolicyKey } from '@/constants/tile-policies';
+// eslint-disable-next-line no-unused-vars
+import { IOption } from '@/interfaces/tile-interfaces';
+// eslint-disable-next-line no-unused-vars
+import { TileObj } from '@/classes/tile-obj';
+import { Simulator } from '@/classes/simulator';
+
+@Options({
+  name: 'PolicyOverlay',
+
+  components: { FocusTrap },
+
+  data: () => ({
+    selectedPolicies: [],
+    // An object mapping policy keys to integers of emission reductions in
+    // Gigatonnes
+    policyEmissions: {},
+  }),
+
+
+  props: {
+    tiles: [],
+  },
+
+  emits: {
+    closed(): void { },
+  },
+
+  methods: {
+    /**
+     * Absorb click events to the content to prevent closing it
+     */
+    absorbClick(clickEvent: MouseEvent) {
+      clickEvent.stopPropagation();
+    },
+
+    closeOverlay() {
+      this.$emit('closed');
+    }
+  },
+
+
+  watch: {
+    // On tiles changed (likely options updated) recalculate temperature
+    tiles: function(newVal) {
+      if (!newVal) {
+        return;
+      }
+    }
+  },
+
+  mounted(): void {
+    this.tiles.forEach((tile: TileObj) => {
+      if (!tile.options) { return; }
+
+      Object.values(tile.options).forEach((tileOption: IOption) => {
+        if (tileOption.policies && tileOption.currPolicyKey !== TilePolicyKey.None) {
+          const policy = tileOption.policies.find(policy => policy.key === tileOption.currPolicyKey);
+
+          if (!policy) { return; }
+
+          this.selectedPolicies.push(policy);
+
+          const policyEmissionDelta = Simulator.getPolicyEmissionsDelta({
+            current: 0,
+            target: policy.target as number,
+            targetYear: policy.targetYear as number,
+            weightPrcnt: tileOption.weightPrcnt,
+            maxCO2Sequestered: tileOption.maxCO2Sequestered,
+          }).total;
+
+          // Round off to the nearest giggatonne, since this is for the UI
+          this.policyEmissions[policy.key] = Math.round(policyEmissionDelta);
+        }
+      });
+    });
+  }
+})
+
+/**
+ * A component that renders an overlay showing what policies the user has
+ * selected, typically once they hit the 1.5°C mark
+ */
+export default class PolicyOverlay extends Vue {
+
+}
+</script>
+
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped lang="scss">
+@import './styles/variables/colors';
+@import './styles/variables/spacing';
+
+h1 { margin-bottom: $standard}
+
+.policy {
+  box-shadow: 0 0.1rem 0.25rem $shadow-medium;
+  border-radius: 0.25rem;
+  padding: $standard;
+  margin-top: $standard;
+  border-left: solid 0.25rem $dark-blue;
+
+  h2 {
+    font-size: 1.25rem;
+    margin-bottom: $tiny;
+  }
+  .emission-change {
+    font-weight: 500;
+    font-size: 0.875rem;
+  }
+  p { margin-top: $small; }
+}
+</style>

--- a/src/components/PolicyOverlay.vue
+++ b/src/components/PolicyOverlay.vue
@@ -4,13 +4,22 @@
       <!-- TODO: Move all text to come from i18n -->
       <div class="overlay-content" @click="absorbClick">
         <div class="title">
-          <h1>Your Policies</h1>
+          <h1 v-if="successState">Great Work, You Did It!</h1>
+          <h1 v-else>Your Policies</h1>
 
           <button id="policy-close" class="btn -blue -light"
             @click="closeOverlay">
             Close
           </button>
         </div>
+
+        <p v-if="successState">
+          <strong>You've reached less than 1.5°C of warming!</strong>
+          The policies you chose will prevent the worst impacts of climate
+          change. Review your selections below, and share what you learned from
+          the Carbon Challenge with your friends and family!
+        </p>
+
 
         <div v-if="selectedPolicies.length > 0" class="temp-info">
           <h2>Outcomes</h2>
@@ -21,8 +30,8 @@
             </strong>
 
             <span v-if="estDegWarming < 1.5" class="temp-info">
-              Great work! Your policy choices will likely avert the largest impacts
-              of
+              Your policy choices will likely avert the largest impacts of
+              climate change. Awesome work!
             </span>
             <span v-else-if="estDegWarming < 2" class="temp-info">
               Almost there! Your policy choices are a great step, but anything
@@ -33,6 +42,12 @@
               That looks like a dangerously hot future! Are there more policies
               you could select to get closer to 1.5°C of warming?
             </span>
+          </p>
+
+          <p v-if="estDegWarming > 1.5">
+            <strong>Tip:</strong> Check out Analytics overlay to learn what
+            tiles are the largest source of emissions - then check out policies
+            available on those tiles!
           </p>
         </div>
 
@@ -53,8 +68,9 @@
           Custom policies are enabled
         </div>
 
-        <!-- Loop through tiles and fetch their policy via -->
-        <ul v-if="selectedPolicies.length > 0">
+        <!-- Loop through tiles and list their selected policies. Uses
+            tabindex="0" to ensure keyboard users can scroll it -->
+        <ul v-if="selectedPolicies.length > 0" tabindex="0">
           <li v-for="(policy) in selectedPolicies" v-bind:key="policy.key" class="policy">
             <h3>
                 <img v-if="policy.isMagic"
@@ -120,6 +136,9 @@ import { Simulator } from '@/classes/simulator';
 
     /** The current simulator settings */
     settings: {} as ISimulatorSettings,
+
+    /** Whether this modal is being shown as the end-game screen */
+    successState: false,
   },
 
   emits: {
@@ -213,7 +232,7 @@ p.temp-info { margin-top: $small; }
 }
 
 ul {
-  max-height: 50vh;
+  max-height: 40vh;
   overflow-y: scroll;
   padding-right: $standard;
   margin-top: $standard;

--- a/src/components/PolicyOverlay.vue
+++ b/src/components/PolicyOverlay.vue
@@ -36,40 +36,40 @@
           </p>
         </div>
 
-        <h2>Policy Selections</h2>
+        <h2 v-if="selectedPolicies.length > 0">Policy Selections</h2>
 
         <!-- Show warnings if magic mode or custom policeis are set -->
         <div v-if="settings.magicModeEnabled" class="warning">
           <img src="@/assets/magic-wand-black.svg"
             class="setting-indicator -magic-mode"
             alt="" width="24" height="24">
-          Magic mode is enabled!
+          Magic mode is enabled
         </div>
 
         <div v-if="settings.customPoliciesEnabled" class="warning">
           <img src="@/assets/graph-black.svg"
             class="setting-indicator -cust-policies"
             alt="" width="24" height="24">
-          Custom Policies Are Enabled!
+          Custom policies are enabled
         </div>
 
         <!-- Loop through tiles and fetch their policy via -->
         <ul v-if="selectedPolicies.length > 0">
           <li v-for="(policy) in selectedPolicies" v-bind:key="policy.key" class="policy">
-            <h2>
+            <h3>
                 <img v-if="policy.isMagic"
                   src="@/assets/magic-wand-black.svg"
                   class="icon -magic-wand"
-                  alt="Magic" width="24" height="24">
+                  alt="Magic" width="18" height="18">
 
                 {{ $t(`simulator.tilePolicies.${policy.key}.name`) }}
-            </h2>
+            </h3>
 
             <div class="emission-change" v-if="policyEmissions[policy.key]">
               {{ policyEmissions[policy.key] }} Gigatonnes CO<sub>2</sub>
             </div>
 
-            <p>
+            <p class="policy-desc">
               {{ $t(`simulator.tilePolicies.${policy.key}.description`) }}
             </p>
           </li>
@@ -187,10 +187,14 @@ export default class PolicyOverlay extends Vue {
 @import './styles/variables/spacing';
 
 // Since this is a very tall modal, make sure it's fully vertically centered
-// rather than skewed to the top
-.overlay-content { margin: 0; }
+// rather than skewed to the top and ensure it never fills the screen
+.overlay-content {
+  margin: 0;
+  max-height: 90vh;
+  overflow-y: auto;
+}
 
-h2 { margin-top: $standard; }
+h2 { margin: $standard 0; }
 
 p.temp {
   font-weight: bold;
@@ -199,7 +203,7 @@ p.temp {
 
 p.temp-info { margin-top: $small; }
 
-p.warning {
+.warning {
   display: inline-flex;
   align-items: center;
   gap: $small;
@@ -220,21 +224,38 @@ ul {
 
 .policy {
   background-color: $white;
-  padding: $m-large;
+  padding: $standard;
   border-left: solid 0.25rem $dark-blue;
   border-radius: 0.25rem;
   box-shadow: 0 0.1rem 0.25rem $shadow-medium;
 
-  + .policy { margin-top: $m-large; }
+  + .policy { margin-top: $standard; }
 
-  h2 {
-    font-size: 1.25rem;
+  h3 {
+    font-size: 1rem;
     margin-bottom: $tiny;
+
+    img { margin-right: $tiny; }
   }
+
   .emission-change {
     font-weight: 500;
     font-size: 0.875rem;
   }
-  p { margin-top: $small; }
+
+  .policy-desc {
+    margin-top: $small;
+    font-size: 0.875rem;
+  }
+}
+
+/**
+ * Mobile styling - make the whole modal scroll rather than the policies list
+ */
+@media (max-width: $mobile-max-width) {
+  ul {
+    max-height: none;
+    overflow-y: hidden;
+  }
 }
 </style>

--- a/src/components/PolicyOverlay.vue
+++ b/src/components/PolicyOverlay.vue
@@ -33,7 +33,7 @@
             </p>
           </li>
         </ul>
-        <p v-else>
+        <p v-else class="empty">
           You haven't selected any policies yet!
         </p>
       </div>
@@ -170,4 +170,6 @@ ul {
   }
   p { margin-top: $small; }
 }
+
+p.empty { margin-top: 0; }
 </style>

--- a/src/components/SimulatorBoard.vue
+++ b/src/components/SimulatorBoard.vue
@@ -4,6 +4,10 @@
       <h1>
         {{ $t('title') }}
 
+        <button @click="currentOverlay = OverlayType.Policy">
+          View Policies
+        </button>
+
         <transition name="fade">
           <img v-if="settings.magicModeEnabled"
             src="@/assets/magic-wand.svg"
@@ -78,6 +82,12 @@
       <WarmingOverlay v-if="currentOverlay === OverlayType.Warming"
         @closed="currentOverlay = undefined"></WarmingOverlay>
     </transition>
+
+    <transition name="fade">
+      <PolicyOverlay v-if="currentOverlay === OverlayType.Policy"
+        :tiles="tiles"
+        @closed="currentOverlay = undefined"></PolicyOverlay>
+    </transition>
   </main>
 </template>
 
@@ -90,26 +100,28 @@ import { TileObj } from '@/classes/tile-obj';
 import { ISimulatorSettings } from '@/interfaces/settings';
 
 import AnalyticsOverlay from './AnalyticsOverlay.vue';
+import PolicyOverlay from './PolicyOverlay.vue';
 import SettingsOverlay from './SettingsOverlay.vue';
 import Thermometer from './Thermometer.vue';
 import Tile from './Tile.vue';
 import TileOverlay from './TileOverlay.vue';
 import WarmingOverlay from './WarmingOverlay.vue';
 
+/* eslint-disable no-unused-vars */
 export enum OverlayType {
-  // eslint-disable-next-line no-unused-vars
   Analytics = 'analytics',
-  // eslint-disable-next-line no-unused-vars
+  Policy = 'policy',
   Settings = 'settings',
-  // eslint-disable-next-line no-unused-vars
   Warming = 'warming',
 }
+/* eslint-enable no-unused-vars */
 
 @Options({
   name: 'SimulatorBoard',
 
   components: {
     AnalyticsOverlay,
+    PolicyOverlay,
     SettingsOverlay,
     Thermometer,
     Tile,

--- a/src/components/SimulatorBoard.vue
+++ b/src/components/SimulatorBoard.vue
@@ -4,10 +4,6 @@
       <h1>
         {{ $t('title') }}
 
-        <button @click="currentOverlay = OverlayType.Policy">
-          View Policies
-        </button>
-
         <transition name="fade">
           <img v-if="settings.magicModeEnabled"
             src="@/assets/magic-wand.svg"
@@ -27,15 +23,21 @@
 
       <div class="btn-cont">
         <button class="btn -transparent -small -flex"
+          @click="currentOverlay = OverlayType.Policy">
+          <img src="@/assets/checklist-white.svg" alt="" width="24" height="24">
+          Policies
+        </button>
+
+        <button class="btn -transparent -small -flex"
           @click="currentOverlay = OverlayType.Analytics">
-          {{ $t('simulator.analytics') }}
           <img src="@/assets/graph.svg" alt="" width="24" height="24">
+          {{ $t('simulator.analytics') }}
         </button>
 
         <button class="btn -transparent -small -flex"
           @click="currentOverlay = OverlayType.Settings">
-          {{ $t('simulator.settings') }}
           <img src="@/assets/settings.svg" alt="" width="24" height="24">
+          {{ $t('simulator.settings') }}
         </button>
       </div>
     </div>

--- a/src/components/SimulatorBoard.vue
+++ b/src/components/SimulatorBoard.vue
@@ -87,6 +87,7 @@
 
     <transition name="fade">
       <PolicyOverlay v-if="currentOverlay === OverlayType.Policy"
+        :settings="settings"
         :tiles="tiles"
         @closed="currentOverlay = undefined"></PolicyOverlay>
     </transition>

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -79,7 +79,7 @@ import { Options, Vue } from 'vue-class-component';
     // On tiles changed (likely options updated) recalculate temperature
     tiles: function(newVal) {
       if (!newVal) {
-          return;
+        return;
       }
 
       this.calculateTemperature();

--- a/src/components/Thermometer.vue
+++ b/src/components/Thermometer.vue
@@ -66,7 +66,14 @@ import { Options, Vue } from 'vue-class-component';
   }),
 
   emits: {
+    /**
+     * Emits when the help button is clicked, which should show the warming info
+     * overlay
+     */
     helpClick(): void { },
+
+    /** Emits when < 1.5 is reached, which should show the success UI */
+    success(): void { },
   },
 
   methods: {
@@ -105,6 +112,10 @@ export default class Thermometer extends Vue {
 
     // Convert decimal temperature rise to a %
     this.avgTempAdjusted = (this.avgTempRise / Thermometer.MaxTempRise) * 100;
+
+    if (this.avgTempRise < 1.5) {
+      this.$emit('success');
+    }
   }
 
   // On Thermometer component being mounted, calculate avg. warming

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -15,7 +15,7 @@
         <a href="https://github.com/vkoves/carbon-challenge">check it out on GitHub</a>!
       </p>
 
-      <h2>Disclaimers</h2>
+      <h2>Simulator Disclaimers</h2>
 
       <p>
         The Carbon Challenge is a project made by non-scientists, and although
@@ -50,6 +50,13 @@
           policy. Our models assume that a ban on gas cars would mean there are
           zero gas vehicles left on the road at all, but that's extremely
           unlikely in the real world.
+        </li>
+        <li>
+          <strong>Emissions linearly impact global temperatures</strong> - the
+          Earth's climate is very complicated, and there can be events (tipping
+          points) that trigger rapid changes to the Earth's temperature. For
+          the Carbon Challenge, however, we assume each ton of carbon increases
+          the Earth's temperature by the same amount.
         </li>
       </ul>
 

--- a/styles/overlay.scss
+++ b/styles/overlay.scss
@@ -39,6 +39,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    margin-bottom: $m-large;
 
     .btn { margin-top: 0; }
   }

--- a/styles/variables/spacing.scss
+++ b/styles/variables/spacing.scss
@@ -8,6 +8,7 @@
 $tiny:      0.25rem;
 $small:     0.5rem;
 $standard:  1rem;
+$m-large:   1.5rem;
 $large:     2rem;
 $x-large:   6rem;
 


### PR DESCRIPTION
Added a new policy modal that shows the user's selected policies and makes some basic suggestions based on the current avg. temperature. Also made it so upon reaching < 1.5 degrees of warming, this modal shows up automatically with some extra text.

| Policy Modal - Early | Policy Modal - Success |
| --- | --- |
| ![Screenshot from 2021-11-24 23-32-10](https://user-images.githubusercontent.com/3187531/143385856-be9d3fd2-0d5e-49b7-99e4-529df806b1c7.png) |  ![Screenshot from 2021-11-24 23-36-10](https://user-images.githubusercontent.com/3187531/143385870-1d306015-53bc-4dc2-8e71-25e283736aee.png) |


**Important:** This PR marks the Carbon Challenge being release ready! :tada: 

Although there is still a lot more work to do (including plenty in internationalization) I think this is good enough to ship to English speaking users and hopefully gauge if this is something folks are excited about.